### PR TITLE
fix: web3py-ext examples

### DIFF
--- a/web3py-ext/web3py_ext/example/transaction/15-fee_delegated_account_update_multisig.py
+++ b/web3py-ext/web3py_ext/example/transaction/15-fee_delegated_account_update_multisig.py
@@ -15,8 +15,8 @@ from web3py_ext.utils.klaytn_utils import (
 )
 from cytoolz import merge
 
-w3 = Web3(Web3.HTTPProvider('http://127.0.0.1:8551'))
-# w3 = Web3(Web3.HTTPProvider('https://public-en-baobab.klaytn.net'))
+# w3 = Web3(Web3.HTTPProvider('http://127.0.0.1:8551'))
+w3 = Web3(Web3.HTTPProvider('https://public-en-baobab.klaytn.net'))
 
 def web3_fee_delegated_account_update_multisig():
     # user1_updator = Account.from_key('0x8b0164c3a59d2b1a00a9934f85ae77c14e21094132c34cc3daacd9e632c90807')
@@ -53,7 +53,13 @@ def web3_fee_delegated_account_update_multisig():
 
     # sign the klaytn specific transaction type with web3py
     signed_tx = Account.sign_transaction(account_update_tx, user1.key)
-    print('\nrawTransaction:', bytes_to_hex_str(signed_tx.rawTransaction))
+    print('\nrawTransaction1:', bytes_to_hex_str(signed_tx.rawTransaction))
+
+    signed_tx2= Account.sign_transaction(signed_tx.rawTransaction, user2.key)
+    print('\nrawTransaction2:', bytes_to_hex_str(signed_tx2.rawTransaction))
+
+    signed_tx3= Account.sign_transaction(signed_tx2.rawTransaction, user3.key)
+    print('\nrawTransaction3:', bytes_to_hex_str(signed_tx3.rawTransaction))
 
     recovered_tx = Account.recover_transaction(signed_tx.rawTransaction)
     print("\nrecovered sender address: ", recovered_tx)
@@ -61,7 +67,7 @@ def web3_fee_delegated_account_update_multisig():
     decoded_tx = Account.decode_transaction(signed_tx.rawTransaction)
     print("\ndecoded transaction:", to_pretty(decoded_tx))
     
-    feepayer_signed_tx = Account.sign_transaction_as_feepayer(signed_tx.rawTransaction, fee_delegator.address, fee_delegator.key)
+    feepayer_signed_tx = Account.sign_transaction_as_feepayer(signed_tx3.rawTransaction, fee_delegator.address, fee_delegator.key)
     print("\nraw transaction of feePayer signed tx:", feepayer_signed_tx.rawTransaction.hex())
     
     feepayer_recovered_tx = Account.recover_transaction_as_feepayer(feepayer_signed_tx.rawTransaction)
@@ -70,7 +76,7 @@ def web3_fee_delegated_account_update_multisig():
     decoded_tx = Account.decode_transaction(feepayer_signed_tx.rawTransaction)
     print("\ndecoded transaction:", to_pretty(decoded_tx))
 
-    tx_hash = w3.eth.send_raw_transaction(signed_tx.rawTransaction)
+    tx_hash = w3.eth.send_raw_transaction(feepayer_signed_tx.rawTransaction)
     tx_receipt = w3.eth.wait_for_transaction_receipt(tx_hash)
     print('tx hash: ', tx_hash, 'receipt: ', tx_receipt) 
 

--- a/web3py-ext/web3py_ext/example/transaction/7-account_update_multisig.py
+++ b/web3py-ext/web3py_ext/example/transaction/7-account_update_multisig.py
@@ -22,7 +22,7 @@ def web3_account_update_multisig():
     user1 = Account.from_key('0xa32c30608667d43be2d652bede413f12a649dd1be93440878e7f712d51a6768a')
     user2 = Account.from_key('0x0e4ca6d38096ad99324de0dde108587e5d7c600165ae4cd6c2462c597458c2b8')
     user3 = Account.from_key('0xc9668ccd35fc20587aa37a48838b48ccc13cf14dd74c8999dd6a480212d5f7ac')
-
+    
     account_update_tx = empty_tx(TxType.ACCOUNT_UPDATE)
     account_update_tx = merge(account_update_tx, {
         'from' : user1.address,
@@ -49,7 +49,13 @@ def web3_account_update_multisig():
     print(to_pretty(account_update_tx))
 
     signed_tx = Account.sign_transaction(account_update_tx, user1.key)
-    print('\nrawTransaction:', bytes_to_hex_str(signed_tx.rawTransaction))
+    print('\nrawTransaction1:', bytes_to_hex_str(signed_tx.rawTransaction))
+
+    signed_tx2= Account.sign_transaction(signed_tx.rawTransaction, user2.key)
+    print('\nrawTransaction2:', bytes_to_hex_str(signed_tx2.rawTransaction))
+
+    signed_tx3= Account.sign_transaction(signed_tx2.rawTransaction, user3.key)
+    print('\nrawTransaction3:', bytes_to_hex_str(signed_tx3.rawTransaction))
 
     recovered_tx = Account.recover_transaction(signed_tx.rawTransaction)
     print("\nrecovered sender address: ", recovered_tx)
@@ -57,7 +63,7 @@ def web3_account_update_multisig():
     decoded_tx = Account.decode_transaction(signed_tx.rawTransaction)
     print("\ndecoded transaction:", to_pretty(decoded_tx))
 
-    tx_hash = w3.eth.send_raw_transaction(signed_tx.rawTransaction)
+    tx_hash = w3.eth.send_raw_transaction(signed_tx3.rawTransaction)
     tx_receipt = w3.eth.wait_for_transaction_receipt(tx_hash)
     print('tx hash: ', tx_hash, 'receipt: ', tx_receipt) 
 

--- a/web3py-ext/web3py_ext/transaction/fee_delegation/fee_delegated_smart_contract_deploy_transaction.py
+++ b/web3py-ext/web3py_ext/transaction/fee_delegation/fee_delegated_smart_contract_deploy_transaction.py
@@ -92,6 +92,13 @@ KLAYTN_TYPED_TRANSACTION_FORMATTERS = merge(
                 (is_bytes, identity),
             )
         ),
+         "feePayerSignatures": apply_formatter_to_array(
+            apply_formatters_to_dict({
+                "v": hexstr_if_str(to_int),
+                "r": hexstr_if_str(to_int),
+                "s": hexstr_if_str(to_int),
+            }),
+        ),
     },
 )
 
@@ -348,10 +355,14 @@ class FeeDelegatedSmartContractDeployTransaction(_TypedTransactionImplementation
 
         # when signing at first time
         transaction_with_signatures = transaction_without_signature_fields
-        if 'feePayerSignatures' not in transaction_without_signature_fields or transaction_with_signatures['feePayerSignatures'][0]['v'] == 1:
-            transaction_with_signatures = merge(transaction_without_signature_fields, {'feePayerSignatures':[]})
+        if 'signatures' not in transaction_without_signature_fields:
+            transaction_with_signatures = merge(transaction_without_signature_fields, {'signatures':[]})
         
-        transaction_with_signatures['feePayerSignatures'].append(vrs)
+        if vrs != {} and vrs not in transaction_with_signatures['signatures']:
+            if type(transaction_with_signatures['signatures']) is not list:
+                transaction_with_signatures['signatures'] = list(transaction_with_signatures['signatures'])
+            transaction_with_signatures['signatures'].append(vrs)
+
         transaction_with_signatures = pipe(
             transaction_with_signatures,
             apply_formatters_to_dict(KLAYTN_TYPED_TRANSACTION_FORMATTERS),


### PR DESCRIPTION
Update examples for web3py-ext:
      - 7-account-update-multisig   
      - 15-fee-delegated-account-update-multisig
      - 12-fee_delegated_smart_contract_deploy_sign_recover (fixed in sdk)