### PR TITLE
feat: release version 1.0.1

### DIFF
--- a/ethers-ext/package.json
+++ b/ethers-ext/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kaiachain/ethers-ext",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "description": "ethers.js extension for kaia blockchain",
   "keywords": [

--- a/web3j-ext/web3j-ext/build.gradle
+++ b/web3j-ext/web3j-ext/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group 'io.kaia'
-version 'v1.0.0'
+version 'v1.0.1'
 
 repositories {
     mavenCentral()

--- a/web3js-ext/package.json
+++ b/web3js-ext/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kaiachain/web3js-ext",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "license": "MIT",
     "description": "web3.js extension for kaiachain blockchain",
     "keywords": [

--- a/web3rpc/sdk/client/java/java-config.yaml
+++ b/web3rpc/sdk/client/java/java-config.yaml
@@ -4,7 +4,7 @@ inputSpec: ../../../rpc-specs/namespaces/all-except-eth.yaml
 groupId: io.kaia
 description: RPC API SDK for kaia blockchain node
 artifactId: web3rpc-java
-artifactVersion: v1.0.0
+artifactVersion: v1.0.1
 library: retrofit2
 templateDir: ./template
 globalProperties:

--- a/web3rpc/sdk/client/javascript/javascript-config.yaml
+++ b/web3rpc/sdk/client/javascript/javascript-config.yaml
@@ -2,7 +2,7 @@ generatorName: web3rpc-javascript
 outputDir: ./openapi
 inputSpec: ../../../rpc-specs/namespaces/all-except-eth.yaml
 projectName: "@kaiachain/web3rpc"
-projectVersion: "1.0.0"
+projectVersion: "1.0.1"
 templateDir: ./template
 sortParamsByRequiredFlag: false
 globalProperties:


### PR DESCRIPTION
- Ethers-ext v1.0.1
  - Includes supporting Ethers v5 and v6 supports in parallel #7 
- Web3js-ext v1.0.1
- Web3j-ext v1.0.1
- Web3rpc java v1.0.1
- Web3rpc javascript v1.0.1