### PR TITLE
feat: update example utils

### DIFF
--- a/web3j-ext/web3j-ext/src/main/java/org/web3j/example/utils/PublicKeyUtilsExample.java
+++ b/web3j-ext/web3j-ext/src/main/java/org/web3j/example/utils/PublicKeyUtilsExample.java
@@ -1,0 +1,17 @@
+package org.web3j.example.utils;
+
+import org.web3j.crypto.transaction.account.AccountKeyPublic;
+import org.web3j.utils.AccountKeyPublicUtils;
+
+
+public class PublicKeyUtilsExample {
+    public static void main(String[] args) {
+
+        System.out.println("From compressed public key to AccountKeyPublic");
+        System.out.println(AccountKeyPublicUtils.decompressKey("03dc9dccbd788c00fa98f7f4082f2f714e799bc0c29d63f04d48b54fe6250453cd"));
+
+        System.out.println("From x,y to compressed public key");
+        AccountKeyPublic publicKey= AccountKeyPublic.create("0xdc9dccbd788c00fa98f7f4082f2f714e799bc0c29d63f04d48b54fe6250453cd","0xaf06ca34ae8714cf3dae06bacdb78c7c2d4054bd38961d40853cd5f15955da79");
+        System.out.println(AccountKeyPublicUtils.toCompressedPublicKey(publicKey.getPublicKey()));
+    }
+}

--- a/web3j-ext/web3j-ext/src/main/java/org/web3j/example/utils/SignatureUtilsExample.java
+++ b/web3j-ext/web3j-ext/src/main/java/org/web3j/example/utils/SignatureUtilsExample.java
@@ -1,0 +1,37 @@
+package org.web3j.example.utils;
+
+
+import org.web3j.crypto.KaiaSignatureData;
+import org.web3j.crypto.Sign;
+import org.web3j.utils.Numeric;
+
+public class SignatureUtilsExample {
+    public static void main(String[] args) {
+        // convert from {r, s, v} signature to string
+        byte[] r = Numeric.hexStringToByteArray("0xbaabb5a43a047e75e41a77b88fa7a5bf89e5227f1c8e40bfdfbcceb8164521ed");
+        byte[] s = Numeric.hexStringToByteArray("0x678f3a7b600169b800828065cda112aa28291311a5dbb729480444a2b905f6e6");
+        byte[] v = Numeric.hexStringToByteArray("0x0");
+        Sign.SignatureData obj = new Sign.SignatureData(v, r, s);
+        String signature = KaiaSignatureData.getSignatureString(obj);
+
+        System.out.println("From {r, s, v} to string " + signature);
+
+        // convert from signature string to {r, s, v}
+        byte[] signatureBytes = Numeric.hexStringToByteArray("0xbaabb5a43a047e75e41a77b88fa7a5bf89e5227f1c8e40bfdfbcceb8164521ed678f3a7b600169b800828065cda112aa28291311a5dbb729480444a2b905f6e600");
+
+        byte[] convertedR = new byte[32];
+        byte[] convertedS = new byte[32];
+        byte[] convertedV= new byte[1];
+
+        // r is the first 32 bytes
+        System.arraycopy(signatureBytes, 0, convertedR, 0, 32);
+        // s is the next 32 bytes
+        System.arraycopy(signatureBytes, 32, convertedS, 0, 32);
+        // v is the last byte
+        convertedV[0] = signatureBytes[64];
+
+        System.out.println("Converted R " + Numeric.toHexString(convertedR));
+        System.out.println("Converted S " + Numeric.toHexString(convertedS));
+        System.out.println("Converted V " + Numeric.toHexString(convertedV));
+    }
+}

--- a/web3j-ext/web3j-ext/src/main/java/org/web3j/example/utils/UnitConvertExample.java
+++ b/web3j-ext/web3j-ext/src/main/java/org/web3j/example/utils/UnitConvertExample.java
@@ -1,0 +1,12 @@
+package org.web3j.example.utils;
+
+import org.web3j.utils.KaiaConvert;
+
+public class UnitConvertExample {
+    public static void main(String[] args) {
+        System.out.println("Convert from kei to kaia " + KaiaConvert.fromKei("1000000000000000000", KaiaConvert.Unit.KAIA));
+        System.out.println("Convert from Gkei to kaia " + KaiaConvert.fromKei("1000000000", KaiaConvert.Unit.GKEI));
+
+        System.out.println("Convert from kaia to kei " + KaiaConvert.toKei("1", KaiaConvert.Unit.KAIA));
+    }
+}

--- a/web3js-ext/example/utils/utils.js
+++ b/web3js-ext/example/utils/utils.js
@@ -1,0 +1,61 @@
+const {
+  TxType,
+  AccountKeyType,
+  getCompressedPublicKey,
+  getSignatureTuple,
+  formatKlayUnits,
+  parseKlayUnits,
+  formatKlay,
+  parseKlay,
+} = require("@kaiachain/web3js-ext");
+
+async function main() {
+  // Transaction and AccountKey types
+  console.log("TxTypeValueTransfer =", TxType.ValueTransfer);
+  console.log("AccountKeyWeightedMultiSig =", AccountKeyType.WeightedMultiSig);
+
+  // ECDSA public key
+  console.log(
+    "pubkey from { x, y } object =",
+    getCompressedPublicKey({
+      x: "0xdc9dccbd788c00fa98f7f4082f2f714e799bc0c29d63f04d48b54fe6250453cd",
+      y: "0xaf06ca34ae8714cf3dae06bacdb78c7c2d4054bd38961d40853cd5f15955da79",
+    })
+  );
+  console.log(
+    "pubkey from uncompressed format =",
+    getCompressedPublicKey(
+      "0x04dc9dccbd788c00fa98f7f4082f2f714e799bc0c29d63f04d48b54fe6250453cdaf06ca34ae8714cf3dae06bacdb78c7c2d4054bd38961d40853cd5f15955da79"
+    )
+  );
+
+  // ECDSA signature
+  console.log(
+    "signature from { v, r, s } object =",
+    getSignatureTuple({
+      v: 27,
+      r: "0x66809fb130a6ea4ae4e823baa92573a5f1bfb4e88e64048aecfb18a2b4012b99",
+      s: "0x75c2c3e5f7b0a182c767137c488649cd5104a5e747371fd922d618e328e5c508",
+    })
+  );
+  console.log(
+    "signature from compact 65 bytes =",
+    getSignatureTuple(
+      "0x66809fb130a6ea4ae4e823baa92573a5f1bfb4e88e64048aecfb18a2b4012b9975c2c3e5f7b0a182c767137c488649cd5104a5e747371fd922d618e328e5c5081b"
+    )
+  );
+
+  // Currency units
+  console.log(
+    "example basefee in ston =",
+    formatKlayUnits("0x5d21dba00", "ston")
+  );
+  console.log("transfer amount in klay =", formatKlay("1230000000000000000"));
+  console.log(
+    "example gas price in peb =",
+    parseKlayUnits("50", "ston").toString()
+  );
+  console.log("transfer amount in peb =", parseKlay("9.87").toString());
+}
+
+main();

--- a/web3py-ext/web3py_ext/example/account/v3_keystore.py
+++ b/web3py-ext/web3py_ext/example/account/v3_keystore.py
@@ -28,3 +28,11 @@ with open('keystore') as f:
     pk = Account.decrypt(f.read(), 'password')
     acc = Account.from_key(pk)
     print(acc.address, acc.key.hex())
+    
+    # create a new keystore with other password
+    new_keystore=Account.encrypt(acc.key.hex(),'password1')
+
+    new_pk = Account.decrypt(new_keystore, 'password1')
+    acc = Account.from_key(pk)
+    print("New keystore")
+    print(acc.address, acc.key.hex())

--- a/web3py-ext/web3py_ext/example/account/v4_keystore.py
+++ b/web3py-ext/web3py_ext/example/account/v4_keystore.py
@@ -2,108 +2,74 @@ from web3py_ext import extend
 from eth_account import Account
 
 v4_keystore_str = '''{
-    "version": 4,
-    "id": "c903083c-a42c-4774-8cea-f4c5a7962732",
-    "address": "0x17226c9b4e130551c258eb7b1cdc927c13998cd6",
-    "keyring": [
-      [
-        {
-          "ciphertext": "e341cf7fb7f19031374a61abb7f2d5d643ca6408bc1e8398de4ac9dd3e0697c1",
-          "cipherparams": { "iv": "fb46dcc6521dc880b54f78891b479dc3" },
-          "cipher": "aes-128-ctr",
-          "kdf": "scrypt",
-          "kdfparams": {
-            "dklen": 32,
-            "salt": "f48e0cd5625e55f62d831d12378fad49ff1a715d490e5996d4a5a275f6a277c2",
-            "n": 4096,
-            "r": 8,
-            "p": 1
-          },
-          "mac": "a03c2c7b6dff1ad793d2ede88a679d82c734e266fcd40bb875d765e50955edb1"
-        },
-        {
-          "ciphertext": "668b1a501bbf756016647397078982e6a413a89ed45e8eefd85fb5de52ea5c10",
-          "cipherparams": { "iv": "ad52c6deefe8fd64ae41dd445c966e08" },
-          "cipher": "aes-128-ctr",
-          "kdf": "scrypt",
-          "kdfparams": {
-            "dklen": 32,
-            "salt": "31cd14d3d15f902989db0f0f9b839a420384252eb7daf7c93ebe1c19c11b0ff2",
-            "n": 4096,
-            "r": 8,
-            "p": 1
-          },
-          "mac": "36b47e3cc20656349ca2477b28ed04585eb5712691ea724437d77c7a876faacd"
-        }
-      ],
-      [
-        {
-          "ciphertext": "6b0f9f13bb721aa97e7eda08cbaaeb873c0ec41f1707b5cd58b8f4932b252067",
-          "cipherparams": { "iv": "755c7b650ac384e45d1825f5e73a7bae" },
-          "cipher": "aes-128-ctr",
-          "kdf": "scrypt",
-          "kdfparams": {
-            "dklen": 32,
-            "salt": "b9e984fe8f8630638aefaf7ad4d112c47acb56ef2b36fb2aaaa29cf149ad32f1",
-            "n": 4096,
-            "r": 8,
-            "p": 1
-          },
-          "mac": "f1bec38f3c815f09d4a4244596b0514c0e24a837979f70773b313c3a873d7b9b"
-        }
-      ],
-      [
-        {
-          "ciphertext": "4ca2438538f560570efe0a862d384d6822513d92fb00503b0cf5f20d5ed959af",
-          "cipherparams": { "iv": "6d578196eff13d42a71d61b54a7a56ac" },
-          "cipher": "aes-128-ctr",
-          "kdf": "scrypt",
-          "kdfparams": {
-            "dklen": 32,
-            "salt": "3a5521134feb81fdd47e91165fc391a2f52984a5fd65b15807843b9bbed3d6dc",
-            "n": 4096,
-            "r": 8,
-            "p": 1
-          },
-          "mac": "b7db297d0a8f7e2044ff7a88da3a27af4a4a3489a210b34911a5c87399075873"
-        },
-        {
-          "ciphertext": "91a2d31625ec96fedf58f0ee48987cf39f6e517103b25d5d0afeac5674c62752",
-          "cipherparams": { "iv": "26821451fdaf5215c028eaea756c2797" },
-          "cipher": "aes-128-ctr",
-          "kdf": "scrypt",
-          "kdfparams": {
-            "dklen": 32,
-            "salt": "a958903f3d1e0065bab28a3c5fb14a2b78804869e1f82a93aabecdc4beded6fd",
-            "n": 4096,
-            "r": 8,
-            "p": 1
-          },
-          "mac": "e9e004e310fa6648b82839c8ace5e215866ef4ae6db9a4b9987678de5817d533"
-        },
-        {
-          "ciphertext": "7ab47009dd5762dd10990f5182228a01cfaef00e8b581c51908de296bbb10cb2",
-          "cipherparams": { "iv": "65d76971b9fae3eca2ff18fca4b23097" },
-          "cipher": "aes-128-ctr",
-          "kdf": "scrypt",
-          "kdfparams": {
-            "dklen": 32,
-            "salt": "288ea98e079125403157a9e9f0546cb1db234637e8d65550dfab607e2e65d065",
-            "n": 4096,
-            "r": 8,
-            "p": 1
-          },
-          "mac": "0a60b6b58b7f6bb50aed38b738deffbe7a9cee593829342ebbd57083a80ac508"
-        }
-      ]
-    ]
-  }'''
+  "version": 4,
+  "id": "15f20a72-3719-4f10-b63d-2dbd2658a3ca",
+  "address": "0x17226c9b4e130551c258eb7b1cdc927c13998cd6",
+  "keyring": [
+    {
+      "ciphertext": "07162b797dcb32dd96686be249f9b3c357642bf5f5454d0fcbefedb265667f37",
+      "cipherparams": {
+        "iv": "8611384aaa8147ef54cbca175d2e818c"
+      },
+      "cipher": "aes-128-ctr",
+      "kdf": "scrypt",
+      "kdfparams": {
+        "dklen": 32,
+        "salt": "d7cb1f18d9fb7aa81042f61a61de9c456f829f2dc8b46cb6290d1bb9de89b791",
+        "n": 4096,
+        "r": 8,
+        "p": 1
+      },
+      "mac": "ed0a57bbb11d512f7e3c3025e6dc497c15a2fa3aad1fe558b4cad53f887e06d8"
+    },
+    {
+      "ciphertext": "394200b0c8abae159e7f19c3eee55409ec789ac77a970e4c3f6bc1839a4afbfc",
+      "cipherparams": {
+        "iv": "3013456d71996e32e231923f289f5c78"
+      },
+      "cipher": "aes-128-ctr",
+      "kdf": "scrypt",
+      "kdfparams": {
+        "dklen": 32,
+        "salt": "fca63eb0670a9bffcc67cb77f43525a8c93d49e0b24acbf7d2a98bff8a5a5cf1",
+        "n": 4096,
+        "r": 8,
+        "p": 1
+      },
+      "mac": "880fa7e1240c1deb18898edea28a2baeb57a0c250971c5fea333033a92a958f7"
+    },
+    {
+      "ciphertext": "e04e0c8c4eaf5a22a037c0771f41e5e3c6e09cf624832a340d1c962ac5aa03cb",
+      "cipherparams": {
+        "iv": "8777c8e5c244190b026c54b4a2474bf0"
+      },
+      "cipher": "aes-128-ctr",
+      "kdf": "scrypt",
+      "kdfparams": {
+        "dklen": 32,
+        "salt": "e4b4d5b664f6722a5ad41a1b46249204326c952b3a4ac255ae4a0b5128e4803a",
+        "n": 4096,
+        "r": 8,
+        "p": 1
+      },
+      "mac": "c618020675a344b3e13dfe9c605115faf32dc80a7d24081b264ebf04fe5db1dd"
+    }
+  ]
+}'''
 
 with open('keystore', 'w') as f:
     f.write(v4_keystore_str)
 
 with open('keystore') as f:
-    pk = Account.v4_decrypt(f.read(), "Klaytn")
+    pk = Account.v4_decrypt(f.read(), "Kaia")
     accs = list(map(lambda acc: Account.from_key_pair(acc['address'], acc['private_key']), pk))
+    print("Original Keystores")
     for acc in accs:
         print(acc.address, acc.key.hex())
+    print("New Keystores")
+    # kaia-sdk only supports encrypting keystore v3
+    for acc in accs:
+      new_keystore=Account.encrypt(acc.key.hex(),'password1')
+      new_pk = Account.decrypt(new_keystore, 'password1')
+      new_acc = Account.from_key(new_pk)
+      print(new_acc.address,new_acc.key.hex())

--- a/web3py-ext/web3py_ext/example/utils/compress_key.py
+++ b/web3py-ext/web3py_ext/example/utils/compress_key.py
@@ -1,0 +1,16 @@
+from eth_account import Account
+from web3py_ext.klaytn_account.utils import compressed_key_from_xy, address_from_private_key, compressed_key, \
+    compressed_key_and_address_from_xy
+
+
+def main():
+    private_key=Account.from_key("0x0e4ca6d38096ad99324de0dde108587e5d7c600165ae4cd6c2462c597458c2b8")
+    print("Public key from private key",address_from_private_key(private_key))
+    print("Compress key from private key",compressed_key(private_key))
+
+    x = "0xdc9dccbd788c00fa98f7f4082f2f714e799bc0c29d63f04d48b54fe6250453cd"
+    y = "0xaf06ca34ae8714cf3dae06bacdb78c7c2d4054bd38961d40853cd5f15955da79"
+    print("Compress public key from x,y", compressed_key_from_xy(x, y))
+    print("Compress public key and address from x,y", compressed_key_and_address_from_xy(x, y))
+
+main()

--- a/web3py-ext/web3py_ext/example/utils/signature_convert.py
+++ b/web3py-ext/web3py_ext/example/utils/signature_convert.py
@@ -1,0 +1,26 @@
+from web3py_ext.utils.klaytn_utils import bytes_to_hex_str, hex_str_to_bytes
+
+def rsv_to_signature_string(r, s, v):
+    # Concatenate r, s, and v to form a 65-byte signature
+    signature = r + s + v
+    return bytes_to_hex_str(signature)
+def signature_string_to_rsv(signature_str):
+    # Convert the signature string to bytes (remove '0x' if present)
+    signature = hex_str_to_bytes(signature_str)
+    # Extract r (first 32 bytes), s (next 32 bytes), and v (last byte)
+    r = signature[:32]
+    s = signature[32:64]
+    v = signature[64]
+    return bytes_to_hex_str(r), bytes_to_hex_str(s), hex(v)
+
+def main():
+    # convert {r,s,v} signature to string
+    r = hex_str_to_bytes('0x678f3a7b600169b800828065cda112aa28291311a5dbb729480444a2b905f6e6')
+    s = hex_str_to_bytes('0xbaabb5a43a047e75e41a77b88fa7a5bf89e5227f1c8e40bfdfbcceb8164521ed')
+    v = hex_str_to_bytes("0x1b")
+    print("From r,s,v to string",rsv_to_signature_string(r,s,v))
+
+    # convert string signature to rsv
+    signature_str="0x66809fb130a6ea4ae4e823baa92573a5f1bfb4e88e64048aecfb18a2b4012b9975c2c3e5f7b0a182c767137c488649cd5104a5e747371fd922d618e328e5c5081b"
+    print("From string to r,s,v",signature_string_to_rsv(signature_str))
+main()

--- a/web3py-ext/web3py_ext/example/utils/unit_convert.py
+++ b/web3py-ext/web3py_ext/example/utils/unit_convert.py
@@ -1,0 +1,11 @@
+from web3py_ext import extend
+from web3 import Web3
+
+def main():
+    # convert from (kei/Gkei/kaia/KAIA) to kei
+    print("From Kaia to Kei", Web3.to_kei(1, 'kei'))
+
+    # convert from kei to (kei/Gkei/kaia/KAIA)
+    print('From Kei to Kaia',Web3.from_kei(1000000000000000000,'kaia'))
+
+main()


### PR DESCRIPTION

Added examples for kaia-sdk: 

1. Web3js-ext:
	- utils.js:  public key conversion, unit conversion, signature conversion examples
2. web3py-ext: 
	- compress_key.py: Convert public key from `{r, s, v}` to `string` and vice versa
	- signature_convert.py: Convert signature from different formats
	- unit_convert.py: Convert units from `kei/Gkei/kaia`
3. web3j-ext: public key conversion, unit conversion, signature conversion examples
	- PublicKeyUtilsExample.java: public key compress and decompress with `AccountKeyPublicUtils`
	- SignatureUtilsExample.java: Convert signature from different formats
	- UnitConvertExample.java: Convert units from `kei/Gkei/kaia`