### PR TITLE
[Unit test] role based key fee payer

### DIFF
--- a/web3js-ext/package-lock.json
+++ b/web3js-ext/package-lock.json
@@ -1,22 +1,22 @@
 {
-    "name": "@klaytn/web3js-ext",
-    "version": "1.0.0",
+    "name": "@kaiachain/web3js-ext",
+    "version": "1.0.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
-            "name": "@klaytn/web3js-ext",
-            "version": "1.0.0",
+            "name": "@kaiachain/web3js-ext",
+            "version": "1.0.1",
             "license": "MIT",
             "dependencies": {
-                "@klaytn/js-ext-core": "^1.0.0",
-                "@klaytn/web3rpc": "^0.9.9",
+                "@kaiachain/js-ext-core": "^1.0.0",
+                "@kaiachain/web3rpc": "^1.0.0",
                 "ethereum-cryptography": "^2.1.2",
                 "lodash": "^4.17.21",
                 "web3": "^4.1.0"
             },
             "devDependencies": {
-                "@klaytn/web3js-ext": "file:./",
+                "@kaiachain/web3js-ext": "file:./",
                 "@types/chai": "^4.3.4",
                 "@types/chai-as-promised": "^7.1.5",
                 "@types/lodash": "^4.14.192",
@@ -794,10 +794,10 @@
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
         },
-        "node_modules/@klaytn/js-ext-core": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@klaytn/js-ext-core/-/js-ext-core-1.0.0.tgz",
-            "integrity": "sha512-OCFHcVHvWrs53hwCMvgcLVyz39Yry1+ppkgx2e/SkrPyUXC2lXNGzoDVxAa04/kfypxP25+0zZJX75ZwOUkYMQ==",
+        "node_modules/@kaiachain/js-ext-core": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@kaiachain/js-ext-core/-/js-ext-core-1.1.0.tgz",
+            "integrity": "sha512-4/f6NPnlddh8EqBPSVGdbenLmGNpCdGBhIvSUAeww55WX23CJ/dfGdesW8Vn0UH7nvxFKmlr8D9juMyQsDEKZw==",
             "dependencies": {
                 "@ethersproject/address": "^5.7.0",
                 "@ethersproject/bignumber": "^5.7.0",
@@ -809,14 +809,14 @@
                 "lodash": "^4.17.21"
             }
         },
-        "node_modules/@klaytn/web3js-ext": {
+        "node_modules/@kaiachain/web3js-ext": {
             "resolved": "",
             "link": true
         },
-        "node_modules/@klaytn/web3rpc": {
-            "version": "0.9.9",
-            "resolved": "https://registry.npmjs.org/@klaytn/web3rpc/-/web3rpc-0.9.9.tgz",
-            "integrity": "sha512-kSh2GurDV3SP0i+3fOmZRm8xJHj43ofyKx32jQ8rxlP4OAo87egG7WLe2usAy77Y+kaecwBxxob+JaSuJ+GSiw==",
+        "node_modules/@kaiachain/web3rpc": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@kaiachain/web3rpc/-/web3rpc-1.0.1.tgz",
+            "integrity": "sha512-S193DG/pxO5YFx3SLtxhNsnDSj4nvNjAFdbzY/D/pY/8sMRKI99GiMh9cInAzVBFkWoGtV9hlmH8COa/SixUuQ==",
             "dependencies": {
                 "@babel/cli": "^7.0.0",
                 "superagent": "^5.3.0"

--- a/web3js-ext/test/role_based_key_feepayer.spec.ts
+++ b/web3js-ext/test/role_based_key_feepayer.spec.ts
@@ -1,0 +1,140 @@
+import { Web3, TxType, AccountKeyType, getPublicKeyFromPrivate, toPeb } from "@kaiachain/web3js-ext";
+import { assert } from "chai";
+
+const senderAddr = "0x334b4d3c775c45c59de54e9f0408cba25a1aece7";
+const senderRoleTransactionPriv = "0xc9668ccd35fc20587aa37a48838b48ccc13cf14dd74c8999dd6a480212d5f7ac";
+const senderRoleAccountUpdatePriv = "0x9ba8cb8f60044058a9e6f815c5c42d3a216f47044c61a1750b6d29ddc7f34bda";
+const senderRoleFeePayerPriv = "0x0e4ca6d38096ad99324de0dde108587e5d7c600165ae4cd6a2462c597458c2b8";
+const receiverAddr = "0xc40b6909eb7085590e1c26cb3becc25368e249e9";
+
+const provider = new Web3.providers.HttpProvider("https://public-en-kairos.node.kaia.io");
+const web3 = new Web3(provider);
+
+const roleAccountUpdate = web3.eth.accounts.privateKeyToAccount(senderRoleAccountUpdatePriv);
+const roleTransactionAccount = web3.eth.accounts.privateKeyToAccount(senderRoleTransactionPriv);
+const roleFeePayerAccount = web3.eth.accounts.privateKeyToAccount(senderRoleFeePayerPriv);
+
+async function checkBalance(address: string) {
+    const balance = await web3.eth.getBalance(address);
+    console.log(`Balance of ${address}: ${web3.utils.fromWei(balance, "ether")} KLAY`);
+    return parseFloat(web3.utils.fromWei(balance, "ether"));
+}
+
+describe("Role-based Key Tests", function () {
+    this.timeout(10000);
+
+    // Before all tests, set up Role-based Key
+    before(async function () {
+        console.log("\n--- Setting Role-based Key ---");
+        const pub1 = getPublicKeyFromPrivate(senderRoleTransactionPriv);
+        const pub2 = getPublicKeyFromPrivate(senderRoleAccountUpdatePriv);
+        const pub3 = getPublicKeyFromPrivate(senderRoleFeePayerPriv);
+
+        const updateTx = {
+            type: TxType.AccountUpdate,
+            from: senderAddr,
+            gasLimit: 100000,
+            key: {
+                type: AccountKeyType.RoleBased,
+                keys: [
+                    { type: AccountKeyType.Public, key: pub1 },
+                    { type: AccountKeyType.Public, key: pub2 },
+                    { type: AccountKeyType.Public, key: pub3 }
+                ]
+            }
+        };
+
+        const signedUpdateTx = await roleAccountUpdate.signTransaction(updateTx);
+        const receipt = await web3.eth.sendSignedTransaction(signedUpdateTx.rawTransaction);
+        console.log("Account Updated:", receipt);
+        assert.isNotNull(receipt.transactionHash, "Account update transaction should succeed");
+    });
+
+    // Test Case 1: Sending a normal transaction with RoleTransaction key
+    it("1. Sending a normal transaction with RoleTransaction key", async function () {
+        const valueTx = {
+            type: TxType.ValueTransfer,
+            from: senderAddr,
+            to: receiverAddr,
+            value: toPeb("0.01"),
+            gasLimit: 100000
+        };
+
+        const signedTx = await roleTransactionAccount.signTransaction(valueTx);
+        const receipt = await web3.eth.sendSignedTransaction(signedTx.rawTransaction);
+        console.log("RoleTransaction signedTx:", receipt.transactionHash);
+        assert.isNotNull(receipt.transactionHash, "RoleTransaction transaction should succeed");
+    });
+
+    // Test Case 2: Attempting to sign a regular transaction with RoleFeePayer key (should fail)
+    it("2. Attempting to sign a regular transaction with RoleFeePayer key (failure test)", async function () {
+        const valueTx = {
+            type: TxType.ValueTransfer,
+            from: senderAddr,
+            to: receiverAddr,
+            value: toPeb("0.01"),
+            gasLimit: 100000
+        };
+
+        try {
+            await roleFeePayerAccount.signTransaction(valueTx);
+            assert.fail("RoleFeePayer key should not sign a regular transaction.");
+        } catch (error: any) {
+            console.log("Expected Error (RoleFeePayer):", error.message);
+            assert.isTrue(true, "Error occurred as expected");
+        }
+    });
+
+    // Test Case 3: Fee Delegated transaction signed by RoleFeePayer key (should succeed)
+    it("3. Fee Delegated transaction signed by RoleFeePayer key (should succeed)", async function () {
+        console.log("\n--- Checking Balances ---");
+        const senderBalance = await checkBalance(senderAddr);
+        const feePayerBalance = await checkBalance(roleFeePayerAccount.address);
+
+        assert.isAbove(senderBalance, 0.01, "Sender account must have enough balance.");
+        assert.isAbove(feePayerBalance, 0.01, "FeePayer account must have enough balance.");
+
+        const feeDelegatedTx = {
+            type: TxType.FeeDelegatedValueTransfer,
+            from: senderAddr,
+            to: receiverAddr,
+            value: toPeb("0.01"),
+            gasLimit: 100000
+        };
+
+        const signedTx = await roleTransactionAccount.signTransaction(feeDelegatedTx);
+        const feePayerSignedTx = await roleFeePayerAccount.signTransaction(signedTx);
+        const receipt = await web3.eth.sendSignedTransaction(feePayerSignedTx.rawTransaction);
+        console.log("Fee Delegated Transaction Hash:", receipt.transactionHash);
+        assert.isNotNull(receipt.transactionHash, "RoleFeePayer transaction should succeed");
+    });
+
+    // Test Case 4: Attempting to sign Fee Delegated transaction with RoleTransaction key (should fail)
+    it("4. Attempting to sign Fee Delegated transaction with RoleTransaction key (should fail)", async function () {
+        console.log("\n--- Checking Balances ---");
+        const senderBalance = await checkBalance(senderAddr);
+
+        assert.isAbove(senderBalance, 0.01, "Sender account should have sufficient balance");
+
+        // Create a FeeDelegatedValueTransfer transaction
+        const feeDelegatedTx = {
+            type: TxType.FeeDelegatedValueTransfer,
+            from: senderAddr,
+            to: receiverAddr,
+            value: toPeb("0.01"),
+            gasLimit: 100000
+        };
+
+        console.log("\n--- Trying to sign Fee Delegated transaction with RoleTransaction key ---");
+
+        // Attempt to sign Fee Delegated transaction with RoleTransaction key
+        try {
+            const signedTx = await roleTransactionAccount.signTransaction(feeDelegatedTx);
+            console.log("Unexpected Success - Fee Delegated Transaction Hash:", signedTx.rawTransaction);
+            assert.fail("RoleTransaction key should not sign Fee Delegated transactions");
+        } catch (error: any) {
+            console.log("Expected Error (RoleTransaction as FeePayer):", error.message);
+            assert.isTrue(true, "Error occurred as expected");
+        }
+    });
+});

--- a/web3js-ext/test/role_based_key_feepayer.spec.ts
+++ b/web3js-ext/test/role_based_key_feepayer.spec.ts
@@ -107,25 +107,33 @@ describe("Role-based Key Tests", function () {
             });
             assert.isNotNull(signedTxByFeePayer.rawTransaction, "FeePayer should sign the transaction");
         } catch (error: any) {
-            console.log("error is :", error.message);
+            console.log("error is : ", error.message);
             assert.fail("FeePayer failed to sign the already signed transaction.");
         }
     });
 
     // Test Case 4: Attempting to sign Fee Delegated transaction with RoleTransaction key (should fail)
     it("4. Attempting to sign Fee Delegated transaction with RoleTransaction key (should fail)", async function () {
+        const userAccount = generateTemporaryAccount();
+
         const feeDelegatedTx = {
             type: TxType.FeeDelegatedValueTransfer,
-            from: generateTemporaryAccount().address,
+            from: userAccount.address,
             to: generateTemporaryAccount().address,
             value: toPeb("0.01"),
             gasLimit: 100000
         };
 
+        const signedTxByUser = await userAccount.signTransaction(feeDelegatedTx);
+        assert.isNotNull(signedTxByUser.rawTransaction, "Transaction should be signed by User");
+        
         try {
-            const signedTx = await roleTransactionAccount.signTransaction(feeDelegatedTx);
+            const signedTxByRoleTransaction = await roleTransactionAccount.signTransaction({
+                senderRawTransaction: signedTxByUser.rawTransaction
+            });
             assert.fail("RoleTransaction key should not sign Fee Delegated transactions");
         } catch (error: any) {
+            console.log("error is : ", error.message);
             assert.isTrue(true, "Error occurred as expected");
         }
     });

--- a/web3js-ext/test/role_based_key_feepayer.spec.ts
+++ b/web3js-ext/test/role_based_key_feepayer.spec.ts
@@ -1,38 +1,43 @@
 import { Web3, TxType, AccountKeyType, getPublicKeyFromPrivate, toPeb } from "@kaiachain/web3js-ext";
 import { assert } from "chai";
 
-const senderAddr = "0x334b4d3c775c45c59de54e9f0408cba25a1aece7";
-const senderRoleTransactionPriv = "0xc9668ccd35fc20587aa37a48838b48ccc13cf14dd74c8999dd6a480212d5f7ac";
-const senderRoleAccountUpdatePriv = "0x9ba8cb8f60044058a9e6f815c5c42d3a216f47044c61a1750b6d29ddc7f34bda";
-const senderRoleFeePayerPriv = "0x0e4ca6d38096ad99324de0dde108587e5d7c600165ae4cd6a2462c597458c2b8";
-const receiverAddr = "0xc40b6909eb7085590e1c26cb3becc25368e249e9";
-
 const provider = new Web3.providers.HttpProvider("https://public-en-kairos.node.kaia.io");
 const web3 = new Web3(provider);
 
-const roleAccountUpdate = web3.eth.accounts.privateKeyToAccount(senderRoleAccountUpdatePriv);
-const roleTransactionAccount = web3.eth.accounts.privateKeyToAccount(senderRoleTransactionPriv);
-const roleFeePayerAccount = web3.eth.accounts.privateKeyToAccount(senderRoleFeePayerPriv);
+type Account = {
+    address: string;
+    privateKey: string;
+    signTransaction: (tx: any) => Promise<any>;
+}
 
-async function checkBalance(address: string) {
-    const balance = await web3.eth.getBalance(address);
-    console.log(`Balance of ${address}: ${web3.utils.fromWei(balance, "ether")} KLAY`);
-    return parseFloat(web3.utils.fromWei(balance, "ether"));
+// Feedback1. Generate Temporary Key.
+function generateTemporaryAccount(): Account {
+    return web3.eth.accounts.create();
 }
 
 describe("Role-based Key Tests", function () {
     this.timeout(10000);
 
+    let roleTransactionAccount: Account;
+    let roleAccountUpdate: Account;
+    let roleFeePayerAccount: Account;
+
     // Before all tests, set up Role-based Key
     before(async function () {
-        console.log("\n--- Setting Role-based Key ---");
-        const pub1 = getPublicKeyFromPrivate(senderRoleTransactionPriv);
-        const pub2 = getPublicKeyFromPrivate(senderRoleAccountUpdatePriv);
-        const pub3 = getPublicKeyFromPrivate(senderRoleFeePayerPriv);
+        console.log("\n--- Generating Temporary Accounts ---");
+        roleTransactionAccount = generateTemporaryAccount();
+        roleAccountUpdate = generateTemporaryAccount();
+        roleFeePayerAccount = generateTemporaryAccount();
 
+        const pub1 = getPublicKeyFromPrivate(roleTransactionAccount.privateKey);
+        const pub2 = getPublicKeyFromPrivate(roleAccountUpdate.privateKey);
+        const pub3 = getPublicKeyFromPrivate(roleFeePayerAccount.privateKey);
+
+        console.log("Generated Public keys:", { pub1, pub2, pub3 });
+        
         const updateTx = {
             type: TxType.AccountUpdate,
-            from: senderAddr,
+            from: roleAccountUpdate.address,
             gasLimit: 100000,
             key: {
                 type: AccountKeyType.RoleBased,
@@ -45,90 +50,88 @@ describe("Role-based Key Tests", function () {
         };
 
         const signedUpdateTx = await roleAccountUpdate.signTransaction(updateTx);
-        const receipt = await web3.eth.sendSignedTransaction(signedUpdateTx.rawTransaction);
-        console.log("Account Updated:", receipt);
-        assert.isNotNull(receipt.transactionHash, "Account update transaction should succeed");
+        console.log("Account Updated:", signedUpdateTx);
+        assert.isNotNull(signedUpdateTx.transactionHash, "Account update transaction should succeed");
     });
 
     // Test Case 1: Sending a normal transaction with RoleTransaction key
     it("1. Sending a normal transaction with RoleTransaction key", async function () {
         const valueTx = {
             type: TxType.ValueTransfer,
-            from: senderAddr,
-            to: receiverAddr,
+            from: generateTemporaryAccount().address,
+            to: generateTemporaryAccount().address,
             value: toPeb("0.01"),
             gasLimit: 100000
         };
 
         const signedTx = await roleTransactionAccount.signTransaction(valueTx);
-        const receipt = await web3.eth.sendSignedTransaction(signedTx.rawTransaction);
-        console.log("RoleTransaction signedTx:", receipt.transactionHash);
-        assert.isNotNull(receipt.transactionHash, "RoleTransaction transaction should succeed");
+        console.log("RoleTransaction signedTx:", signedTx.transactionHash);
+        assert.isNotNull(signedTx.transactionHash, "RoleTransaction transaction should succeed");
     });
 
     // Test Case 2: Attempting to sign a regular transaction with RoleFeePayer key (should fail)
     it("2. Attempting to sign a regular transaction with RoleFeePayer key (failure test)", async function () {
         const valueTx = {
             type: TxType.ValueTransfer,
-            from: senderAddr,
-            to: receiverAddr,
+            from: generateTemporaryAccount().address,
+            to: generateTemporaryAccount().address,
             value: toPeb("0.01"),
             gasLimit: 100000
         };
 
         try {
             const signedTx = await roleFeePayerAccount.signTransaction(valueTx);
-            const receipt = await web3.eth.sendSignedTransaction(signedTx.rawTransaction);
-            console.log("Unexpected Success - Transaction Hash:", receipt.transactionHash);
-            assert.fail("RoleFeePayer key should not sign a regular transaction.");
+            console.log("Unexpected Success - Signed Transaction:", signedTx);
+            assert.fail("RoleFeePayer key should not sign a ValueTransfer transaction.");
         } catch (error: any) {
             console.log("Expected Error (RoleFeePayer):", error.message);
-            assert.isTrue(true, "Error occurred as expected");
+            assert.isTrue(true, "Error occurred as expected due to role mismatch");
         }
     });
 
     // Test Case 3: Fee Delegated transaction signed by RoleFeePayer key (should succeed)
-    it("3. Fee Delegated transaction signed by RoleFeePayer key (should succeed)", async function () {
-        console.log("\n--- Checking Balances ---");
-        const senderBalance = await checkBalance(senderAddr);
-        const feePayerBalance = await checkBalance(roleFeePayerAccount.address);
-
-        assert.isAbove(senderBalance, 0.01, "Sender account must have enough balance.");
-        assert.isAbove(feePayerBalance, 0.01, "FeePayer account must have enough balance.");
-
+    it("3. Fee Delegated transaction signed by RoleTransaction and RoleFeePayer keys", async function () {
         const feeDelegatedTx = {
             type: TxType.FeeDelegatedValueTransfer,
-            from: senderAddr,
-            to: receiverAddr,
+            from: generateTemporaryAccount().address,
+            to: generateTemporaryAccount().address,
             value: toPeb("0.01"),
             gasLimit: 100000
         };
 
-        const signedTx = await roleFeePayerAccount.signTransaction(feeDelegatedTx);
-        const receipt = await web3.eth.sendSignedTransaction(signedTx.rawTransaction);
-        console.log("Fee Delegated Transaction Hash:", receipt.transactionHash);
-        assert.isNotNull(receipt.transactionHash, "RoleFeePayer transaction should succeed");
+        // Feedback2. Remove the dependencies with network connection. just check the signed result.
+        // Feedback3. signed by a user (from address,roleTransactionAccount) first
+        const signedTxBySender = await roleTransactionAccount.signTransaction(feeDelegatedTx);
+        assert.isNotNull(signedTxBySender.rawTransaction, "Transaction should be signed by RoleTransaction");
+
+        console.log("Sender signed transaction:", signedTxBySender.rawTransaction);
+
+        // Feedback3. FeePayer(FeePayerAccount) sign the tx after the user's sign.
+        try {
+            const signedTxByFeePayer = await roleFeePayerAccount.signTransaction({
+                senderRawTransaction: signedTxBySender.rawTransaction
+            });
+            assert.isNotNull(signedTxByFeePayer.rawTransaction, "FeePayer should sign the transaction");
+            console.log("Signed Fee Delegated Transaction:", signedTxByFeePayer.rawTransaction);
+        } catch (error: any) {
+            console.log("Expected Error (FeePayer signing):", error.message);
+            assert.fail("FeePayer failed to sign the already signed transaction.");
+        }
     });
 
     // Test Case 4: Attempting to sign Fee Delegated transaction with RoleTransaction key (should fail)
     it("4. Attempting to sign Fee Delegated transaction with RoleTransaction key (should fail)", async function () {
-        console.log("\n--- Checking Balances ---");
-        const senderBalance = await checkBalance(senderAddr);
-
-        assert.isAbove(senderBalance, 0.01, "Sender account should have sufficient balance");
-
         const feeDelegatedTx = {
             type: TxType.FeeDelegatedValueTransfer,
-            from: senderAddr,
-            to: receiverAddr,
+            from: generateTemporaryAccount().address,
+            to: generateTemporaryAccount().address,
             value: toPeb("0.01"),
             gasLimit: 100000
         };
 
         try {
             const signedTx = await roleTransactionAccount.signTransaction(feeDelegatedTx);
-            const receipt = await web3.eth.sendSignedTransaction(signedTx.rawTransaction);
-            console.log("Unexpected Success - Transaction Hash:", receipt.transactionHash);
+            console.log("Unexpected Success - Transaction Hash:", signedTx.transactionHash);
             assert.fail("RoleTransaction key should not sign Fee Delegated transactions");
         } catch (error: any) {
             console.log("Expected Error (RoleTransaction as FeePayer):", error.message);

--- a/web3js-ext/test/role_based_key_feepayer.spec.ts
+++ b/web3js-ext/test/role_based_key_feepayer.spec.ts
@@ -93,7 +93,10 @@ describe("Role-based Key Tests", function () {
             from: userAccount.address,
             to: generateTemporaryAccount().address,
             value: toPeb("0.01"),
-            gasLimit: 100000
+            gasLimit: "100000", 
+            gasPrice: "25000000000", 
+            nonce: "0x0",
+            chainId: "0x1001" 
         };
 
         // Feedback 4. User signs transaction first
@@ -103,7 +106,9 @@ describe("Role-based Key Tests", function () {
         // Feedback 4. FeePayer adds an additional signature
         try {
             const signedTxByFeePayer = await roleFeePayerAccount.signTransaction({
-                senderRawTransaction: signedTxByUser.rawTransaction
+                senderRawTransaction: signedTxByUser.rawTransaction,
+                gasPrice: "25000000000",
+                gasLimit: "100000" 
             });
             assert.isNotNull(signedTxByFeePayer.rawTransaction, "FeePayer should sign the transaction");
         } catch (error: any) {
@@ -121,7 +126,10 @@ describe("Role-based Key Tests", function () {
             from: userAccount.address,
             to: generateTemporaryAccount().address,
             value: toPeb("0.01"),
-            gasLimit: 100000
+            gasLimit: 100000,
+            gasPrice: "25000000000", 
+            nonce: "0x0",
+            chainId: "0x1001"
         };
 
         const signedTxByUser = await userAccount.signTransaction(feeDelegatedTx);
@@ -129,9 +137,10 @@ describe("Role-based Key Tests", function () {
         
         try {
             const signedTxByRoleTransaction = await roleTransactionAccount.signTransaction({
-                senderRawTransaction: signedTxByUser.rawTransaction
-            });
-            assert.fail("RoleTransaction key should not sign Fee Delegated transactions");
+                senderRawTransaction: signedTxByUser.rawTransaction,
+                gasPrice: "25000000000",
+                gasLimit: "100000"
+            })
         } catch (error: any) {
             console.log("error is : ", error.message);
             assert.isTrue(true, "Error occurred as expected");

--- a/web3js-ext/test/role_based_key_feepayer.spec.ts
+++ b/web3js-ext/test/role_based_key_feepayer.spec.ts
@@ -4,183 +4,238 @@ import { assert } from "chai";
 const provider = new Web3.providers.HttpProvider("https://public-en-kairos.node.kaia.io");
 const web3 = new Web3(provider);
 
+// Helper function to generate a temporary account
 type Account = {
-    address: string;
-    privateKey: string;
-    signTransaction: (tx: any) => Promise<any>;
-}
+  address: string;
+  privateKey: string;
+  signTransaction: (tx: any) => Promise<any>;
+};
 
-// Feedback1. Generate Temporary Key.
 function generateTemporaryAccount(): Account {
-    return web3.eth.accounts.create();
+  return web3.eth.accounts.create();
 }
 
 describe("Role-based Key Tests", function () {
-    this.timeout(10000);
+  this.timeout(200000);
 
-    let roleTransactionAccount: Account;
-    let roleAccountUpdate: Account;
-    let roleFeePayerAccount: Account;
+  let roleTransactionAccount: Account;
+  let roleAccountUpdate: Account;
+  let roleFeePayerAccount: Account;
 
-    // Before all tests, set up Role-based Key
-    before(async function () {
-        roleTransactionAccount = generateTemporaryAccount();
-        roleAccountUpdate = generateTemporaryAccount();
-        roleFeePayerAccount = generateTemporaryAccount();
+  // --- Test Cases 1-4: Local signature tests (no real network sends) ---
+  before(async function () {
+    roleTransactionAccount = generateTemporaryAccount();
+    roleAccountUpdate = generateTemporaryAccount();
+    roleFeePayerAccount = generateTemporaryAccount();
 
-        // Feedback 5. PubKey name change
-        const roleTransactionAccountPubkey = getPublicKeyFromPrivate(roleTransactionAccount.privateKey);
-        const roleAccountUpdatePubKey = getPublicKeyFromPrivate(roleAccountUpdate.privateKey);
-        const roleFeePayerPubkey = getPublicKeyFromPrivate(roleFeePayerAccount.privateKey);
+    const roleTransactionAccountPubkey = getPublicKeyFromPrivate(roleTransactionAccount.privateKey);
+    const roleAccountUpdatePubkey = getPublicKeyFromPrivate(roleAccountUpdate.privateKey);
+    const roleFeePayerPubkey = getPublicKeyFromPrivate(roleFeePayerAccount.privateKey);
 
-        const updateTx = {
-            type: TxType.AccountUpdate,
-            from: roleAccountUpdate.address,
-            gasLimit: 100000,
-            key: {
-                type: AccountKeyType.RoleBased,
-                keys: [
-                    { type: AccountKeyType.Public, key: roleTransactionAccountPubkey },
-                    { type: AccountKeyType.Public, key: roleAccountUpdatePubKey },
-                    { type: AccountKeyType.Public, key: roleFeePayerPubkey }
-                ]
-            }
-        };
+    const updateTx = {
+      type: TxType.AccountUpdate,
+      from: roleAccountUpdate.address,
+      gasLimit: 100000,
+      key: {
+        type: AccountKeyType.RoleBased,
+        keys: [
+          { type: AccountKeyType.Public, key: roleTransactionAccountPubkey },
+          { type: AccountKeyType.Public, key: roleAccountUpdatePubkey },
+          { type: AccountKeyType.Public, key: roleFeePayerPubkey }
+        ]
+      }
+    };
 
-        const signedUpdateTx = await roleAccountUpdate.signTransaction(updateTx);
-        assert.isNotNull(signedUpdateTx.transactionHash, "Account update transaction should succeed");
-    });
+    const signedUpdateTx = await roleAccountUpdate.signTransaction(updateTx);
+    assert.isNotNull(signedUpdateTx.transactionHash, "Account update transaction should succeed");
+  });
 
-    // Test Case 1: Sending a normal transaction with RoleTransaction key
-    it("1. Sending a normal transaction with RoleTransaction key", async function () {
-        const valueTx = {
-            type: TxType.ValueTransfer,
-            from: generateTemporaryAccount().address,
-            to: generateTemporaryAccount().address,
-            value: toPeb("0.01"),
-            gasLimit: 100000
-        };
+  it("1. Sending a normal transaction with RoleTransaction key", async function () {
+    const valueTx = {
+      type: TxType.ValueTransfer,
+      from: generateTemporaryAccount().address,
+      to: generateTemporaryAccount().address,
+      value: toPeb("0.01"),
+      gasLimit: 100000
+    };
 
-        const signedTx = await roleTransactionAccount.signTransaction(valueTx);
-        assert.isNotNull(signedTx.transactionHash, "RoleTransaction transaction should succeed");
-    });
+    const signedTx = await roleTransactionAccount.signTransaction(valueTx);
+    assert.isNotNull(signedTx.transactionHash, "RoleTransaction transaction should succeed");
+  });
 
-    // Test Case 2: Attempting to sign a regular transaction with RoleFeePayer key (should fail)
-    it("2. Attempting to sign a regular transaction with RoleFeePayer key (failure test)", async function () {
-        const valueTx = {
-            type: TxType.ValueTransfer,
-            from: generateTemporaryAccount().address,
-            to: generateTemporaryAccount().address,
-            value: toPeb("0.01"),
-            gasLimit: 100000
-        };
+  it("2. Attempting to sign a regular transaction with RoleFeePayer key (should fail)", async function () {
+    const valueTx = {
+      type: TxType.ValueTransfer,
+      from: generateTemporaryAccount().address,
+      to: generateTemporaryAccount().address,
+      value: toPeb("0.01"),
+      gasLimit: 100000
+    };
 
-        try {
-            const signedTx = await roleFeePayerAccount.signTransaction(valueTx);
-            assert.fail("RoleFeePayer key should not sign a ValueTransfer transaction.");
-        } catch (error: any) {
-            assert.isTrue(true, "Error occurred as expected due to role mismatch");
-        }
-    });
+    try {
+      await roleFeePayerAccount.signTransaction(valueTx);
+      assert.fail("RoleFeePayer key should not sign a ValueTransfer transaction.");
+    } catch (error: any) {
+      assert.isTrue(true, "Error occurred as expected due to role mismatch");
+    }
+  });
 
-    it("3. Fee Delegated transaction signed by RoleTransaction and RoleFeePayer keys", async function () {
-        const userAccount = generateTemporaryAccount();
-    
-        const feeDelegatedTx = {
-            type: TxType.FeeDelegatedValueTransfer,
-            from: userAccount.address,
-            to: generateTemporaryAccount().address,
-            value: toPeb("0.01"),
-            gasLimit: "100000",
-            gasPrice: "25000000000",
-            nonce: "0x0",
-            chainId: "0x1001"
-        };
-    
-        // 1) A User signs a transaction
-        const signedTxByUser = await userAccount.signTransaction(feeDelegatedTx);
-        assert.isNotNull(signedTxByUser.rawTransaction, "Transaction should be signed by User");
-    
-        console.log("Signed Transaction by User (rawTransaction):", signedTxByUser.rawTransaction);
-    
-        try {
-            // 2) FeePayer signs a transaction
-            const feePayerSignInput = {
-                type: feeDelegatedTx.type,
-                from: feeDelegatedTx.from,
-                to: feeDelegatedTx.to,
-                value: feeDelegatedTx.value,
-                gasPrice: feeDelegatedTx.gasPrice,
-                gasLimit: feeDelegatedTx.gasLimit,
-                nonce: feeDelegatedTx.nonce,
-                chainId: feeDelegatedTx.chainId,
-                feePayer: roleFeePayerAccount.address,
-                senderRawTransaction: signedTxByUser.rawTransaction,
-            };
-            console.log("FeePayer SignTransaction Input:", feePayerSignInput);
-    
-            const signedTxByFeePayer = await roleFeePayerAccount.signTransaction(feePayerSignInput);
-            assert.isNotNull(signedTxByFeePayer.rawTransaction, "FeePayer should sign the transaction");
-    
-            console.log("Signed Transaction by FeePayer (rawTransaction):", signedTxByFeePayer.rawTransaction);
-    
-            // 3) RLP format check
-            if (!signedTxByFeePayer.rawTransaction.startsWith("0x")) {
-                console.error("Invalid rawTransaction format");
-            } else {
-                // 4) RLP Decoding
-                const { KlaytnTxFactory } = require("@kaiachain/web3js-ext");
-                const decoded = KlaytnTxFactory.fromRLP(signedTxByFeePayer.rawTransaction);
-                console.log("Decoded Transaction:", decoded);
-    
-                // feepayer field check
-                if (decoded.fields.feePayer) {
-                    console.log("Decoded feePayer Field:", decoded.fields.feePayer);
-                    // Check if feepayer and roleFeePayerAccount.address are the same
-                    assert.equal( 
-                        decoded.fields.feePayer.toLowerCase(),
-                        roleFeePayerAccount.address.toLowerCase(),
-                        "FeePayer address should match roleFeePayerAccount"
-                    );
-                } else {
-                    // Unsigned if the feePayer field itself is not present
-                    console.error("No feePayer field found in decoded transaction.");
-                    assert.fail("FeePayer address not found in the final transaction.");
-                }
-            }
-        } catch (error: any) {
-            console.log("Error during FeePayer signing or decoding:", error.message);
-            assert.fail("FeePayer failed to sign the already signed transaction.");
-        }
-    });
+  it("3. Fee Delegated transaction signed by RoleTransaction and RoleFeePayer keys", async function () {
+    const userAccount = generateTemporaryAccount();
 
-    // Test Case 4: Attempting to sign Fee Delegated transaction with RoleTransaction key (should fail)
-    it("4. Attempting to sign Fee Delegated transaction with RoleTransaction key (should fail)", async function () {
-        const userAccount = generateTemporaryAccount();
+    const feeDelegatedTx = {
+      type: TxType.FeeDelegatedValueTransfer,
+      from: userAccount.address,
+      to: generateTemporaryAccount().address,
+      value: toPeb("0.01"),
+      gasLimit: "100000",
+      gasPrice: "25000000000",
+      nonce: "0x0",
+      chainId: "0x1001"
+    };
 
-        const feeDelegatedTx = {
-            type: TxType.FeeDelegatedValueTransfer,
-            from: userAccount.address,
-            to: generateTemporaryAccount().address,
-            value: toPeb("0.01"),
-            gasLimit: 100000,
-            gasPrice: "25000000000",
-            nonce: "0x0",
-            chainId: "0x1001"
-        };
+    // Step 1: User (RoleTransaction) signs the transaction
+    const signedTxByUser = await userAccount.signTransaction(feeDelegatedTx);
+    assert.isNotNull(signedTxByUser.rawTransaction, "Transaction should be signed by User");
+    console.log("Signed Transaction by User (rawTransaction):", signedTxByUser.rawTransaction);
 
-        const signedTxByUser = await userAccount.signTransaction(feeDelegatedTx);
-        assert.isNotNull(signedTxByUser.rawTransaction, "Transaction should be signed by User");
+    // Step 2: FeePayer (RoleFeePayer) signs the transaction
+    try {
+      const feePayerSignInput = {
+        type: feeDelegatedTx.type,
+        from: feeDelegatedTx.from,
+        to: feeDelegatedTx.to,
+        value: feeDelegatedTx.value,
+        gasPrice: feeDelegatedTx.gasPrice,
+        gasLimit: feeDelegatedTx.gasLimit,
+        nonce: feeDelegatedTx.nonce,
+        chainId: feeDelegatedTx.chainId,
+        feePayer: roleFeePayerAccount.address,
+        senderRawTransaction: signedTxByUser.rawTransaction,
+      };
+      console.log("FeePayer SignTransaction Input:", feePayerSignInput);
 
-        try {
-            const signedTxByRoleTransaction = await roleTransactionAccount.signTransaction({
-                senderRawTransaction: signedTxByUser.rawTransaction,
-                gasPrice: "25000000000",
-                gasLimit: "100000"
-            })
-        } catch (error: any) {
-            console.log("error is : ", error.message);
-            assert.isTrue(true, "Error occurred as expected");
-        }
-    });
+      const signedTxByFeePayer = await roleFeePayerAccount.signTransaction(feePayerSignInput);
+      assert.isNotNull(signedTxByFeePayer.rawTransaction, "FeePayer should sign the transaction");
+      console.log("Signed Transaction by FeePayer (rawTransaction):", signedTxByFeePayer.rawTransaction);
+    } catch (error: any) {
+      console.log("Error during FeePayer signing:", error.message);
+      assert.fail("FeePayer failed to sign the already signed transaction.");
+    }
+  });
+
+  it("4. Attempting to sign Fee Delegated transaction with RoleTransaction key (should fail)", async function () {
+    const userAccount = generateTemporaryAccount();
+
+    const feeDelegatedTx = {
+      type: TxType.FeeDelegatedValueTransfer,
+      from: userAccount.address,
+      to: generateTemporaryAccount().address,
+      value: toPeb("0.01"),
+      gasLimit: 100000,
+      gasPrice: "25000000000",
+      nonce: "0x0",
+      chainId: "0x1001"
+    };
+
+    const signedTxByUser = await userAccount.signTransaction(feeDelegatedTx);
+    assert.isNotNull(signedTxByUser.rawTransaction, "Transaction should be signed by User");
+
+    try {
+      await roleTransactionAccount.signTransaction({
+        senderRawTransaction: signedTxByUser.rawTransaction,
+        gasPrice: "25000000000",
+        gasLimit: "100000"
+      });
+      assert.fail("RoleTransaction key should not sign FeeDelegated transaction");
+    } catch (error: any) {
+      console.log("Expected error (RoleTransaction as FeePayer):", error.message);
+      assert.isTrue(true, "Error occurred as expected");
+    }
+  });
+
+  // --- Test Case 5: Real Network Send & Fee Payer Check via getTransaction ---
+  it("5. [REAL SEND] RoleBased + FeeDelegatedValueTransfer, check feePayer via getTransaction", async function () {
+    // Step 1: Prepare legacyA (for value transfer) and legacyB (for fee payment), test accouont created by Kaia Online Toolkit
+    const legacyA = web3.eth.accounts.privateKeyToAccount("0x21040aa5efd8548b18d71aaea183f38cf242237d1cff1274fba02d57a35baac7");
+    const legacyB = web3.eth.accounts.privateKeyToAccount("0x7833d6a97880af896ee1c042d7965c952b4592a318cff584bedb966ec24e2069");
+
+    console.log("[Test5] legacyA (TxKey):", legacyA.address);
+    console.log("[Test5] legacyB (FeePayerKey):", legacyB.address);
+
+    // Step 2: Update legacyA to a RoleBased account
+    // Set RoleTransaction = legacyA, RoleAccountUpdate = legacyA, RoleFeePayer = legacyB
+    const pubA = getPublicKeyFromPrivate(legacyA.privateKey);
+    const pubB = getPublicKeyFromPrivate(legacyB.privateKey);
+
+    console.log("[Test5] Updating legacyA to RoleBased...");
+    const accountUpdateTx = {
+      type: TxType.AccountUpdate,
+      from: legacyA.address,
+      gas: 300000,
+      gasPrice: "25000000000",
+      key: {
+        type: AccountKeyType.RoleBased,
+        keys: [
+          { type: AccountKeyType.Public, key: pubA }, // RoleTransaction
+          { type: AccountKeyType.Public, key: pubA }, // RoleAccountUpdate
+          { type: AccountKeyType.Public, key: pubB }  // RoleFeePayer
+        ]
+      }
+    };
+
+    const signedUpdateTx = await web3.eth.accounts.signTransaction(accountUpdateTx, legacyA.privateKey);
+    const receiptUpdate = await web3.eth.sendSignedTransaction(signedUpdateTx.rawTransaction);
+    assert.isNotNull(receiptUpdate.transactionHash, "[Test5] AccountUpdate must be mined");
+    console.log("[Test5] AccountUpdate TxHash:", receiptUpdate.transactionHash);
+
+    // Step 3: Create FeeDelegatedValueTransfer transaction from legacyA to a new receiver
+    const receiver = generateTemporaryAccount();
+    const feeDelegatedTx = {
+      type: TxType.FeeDelegatedValueTransfer,
+      from: legacyA.address,
+      to: receiver.address,
+      value: toPeb("0.1"),  // Transfer 0.1 KLAY
+      gas: 300000,
+      gasPrice: "25000000000",
+    };
+
+    // Step 4: Sign the transaction with legacyA (RoleTransaction)
+    const userSigned = await web3.eth.accounts.signTransaction(feeDelegatedTx, legacyA.privateKey);
+    assert.isNotNull(userSigned.rawTransaction, "[Test5] User-signed transaction must exist");
+
+    // Step 5: Sign the transaction with legacyB (RoleFeePayer) with feePayer field set to legacyA's address
+    const feePayerSignInput = {
+      senderRawTransaction: userSigned.rawTransaction,
+      feePayer: legacyA.address, // The feePayer field should be set to legacyA's address
+    };
+    const feePayerSigned = await web3.eth.accounts.signTransaction(feePayerSignInput, legacyB.privateKey);
+    assert.isNotNull(feePayerSigned.rawTransaction, "[Test5] FeePayer-signed transaction must exist");
+
+    console.log("[Test5] Sending FeeDelegated transaction to network...");
+    const receiptFD = await web3.eth.sendSignedTransaction(feePayerSigned.rawTransaction);
+    assert.isNotNull(receiptFD.transactionHash, "[Test5] FeeDelegated transaction must be mined");
+    console.log("[Test5] FeeDelegated TxHash:", receiptFD.transactionHash);
+
+    // Step 6: Retrieve transaction details via web3.eth.getTransaction
+    const txDetails = await web3.eth.getTransaction(receiptFD.transactionHash);
+    console.log("[Test5] Transaction details:", txDetails);
+
+    // Access feePayer field using type-casting (as any)
+    const feePayerField = (txDetails as any).feePayer;
+    if (feePayerField) {
+      console.log("[Test5] feePayer from getTransaction:", feePayerField);
+      assert.equal(
+        feePayerField.toLowerCase(),
+        legacyA.address.toLowerCase(),
+        "[Test5] feePayer field should match legacyA address"
+      );
+    } else {
+      console.log("[Test5] feePayer field is not available in the transaction details returned by getTransaction.");
+    }
+
+    // Step 7: Log the receiver's balance for verification purposes
+    const receiverBalance = await web3.eth.getBalance(receiver.address);
+    console.log("[Test5] Receiver balance:", receiverBalance, "Peb");
+  });
 });

--- a/web3js-ext/test/role_based_key_feepayer.spec.ts
+++ b/web3js-ext/test/role_based_key_feepayer.spec.ts
@@ -77,7 +77,9 @@ describe("Role-based Key Tests", function () {
         };
 
         try {
-            await roleFeePayerAccount.signTransaction(valueTx);
+            const signedTx = await roleFeePayerAccount.signTransaction(valueTx);
+            const receipt = await web3.eth.sendSignedTransaction(signedTx.rawTransaction);
+            console.log("Unexpected Success - Transaction Hash:", receipt.transactionHash);
             assert.fail("RoleFeePayer key should not sign a regular transaction.");
         } catch (error: any) {
             console.log("Expected Error (RoleFeePayer):", error.message);
@@ -102,9 +104,8 @@ describe("Role-based Key Tests", function () {
             gasLimit: 100000
         };
 
-        const signedTx = await roleTransactionAccount.signTransaction(feeDelegatedTx);
-        const feePayerSignedTx = await roleFeePayerAccount.signTransaction(signedTx);
-        const receipt = await web3.eth.sendSignedTransaction(feePayerSignedTx.rawTransaction);
+        const signedTx = await roleFeePayerAccount.signTransaction(feeDelegatedTx);
+        const receipt = await web3.eth.sendSignedTransaction(signedTx.rawTransaction);
         console.log("Fee Delegated Transaction Hash:", receipt.transactionHash);
         assert.isNotNull(receipt.transactionHash, "RoleFeePayer transaction should succeed");
     });
@@ -116,7 +117,6 @@ describe("Role-based Key Tests", function () {
 
         assert.isAbove(senderBalance, 0.01, "Sender account should have sufficient balance");
 
-        // Create a FeeDelegatedValueTransfer transaction
         const feeDelegatedTx = {
             type: TxType.FeeDelegatedValueTransfer,
             from: senderAddr,
@@ -125,12 +125,10 @@ describe("Role-based Key Tests", function () {
             gasLimit: 100000
         };
 
-        console.log("\n--- Trying to sign Fee Delegated transaction with RoleTransaction key ---");
-
-        // Attempt to sign Fee Delegated transaction with RoleTransaction key
         try {
             const signedTx = await roleTransactionAccount.signTransaction(feeDelegatedTx);
-            console.log("Unexpected Success - Fee Delegated Transaction Hash:", signedTx.rawTransaction);
+            const receipt = await web3.eth.sendSignedTransaction(signedTx.rawTransaction);
+            console.log("Unexpected Success - Transaction Hash:", receipt.transactionHash);
             assert.fail("RoleTransaction key should not sign Fee Delegated transactions");
         } catch (error: any) {
             console.log("Expected Error (RoleTransaction as FeePayer):", error.message);


### PR DESCRIPTION
## **Test Overview**
- A unit test that uses web3js-ext to create a feepayer key as a role-based account(RoleFeePayer), and checks whether transactions can be performed according to each role.

## **Reference**
- [Kaia Docs - AccountKeyRoleBased](https://docs.kaia.io/learn/accounts/#accountkeyrolebased-)
- [Kaia Docs - ValueTransfer](https://docs.kaia.io/references/sdk/web3js-ext/fee-delegated-transaction/value-transfer/)
- [web3js-ext - sign_msg_AccountKeyRoleBased.js](https://github.com/kaiachain/kaia-sdk/blob/dev/web3js-ext/example/accountKey/sign_msg_AccountKeyRoleBased.js)
- [web3js-ext - update_AccountKeyRoleBased.js](https://github.com/kaiachain/kaia-sdk/blob/dev/web3js-ext/example/accountKey/update_AccountKeyRoleBased.js)

## Understanding of the author, about Role-based Key
(If there was a misunderstanding, the test case itself could be wrong....)
- Kaia blockchain can distinguish roles by RoleTransaction, RoleAccountUpdate, RoleFeePayer through RoleBasedKey, and can sign each transaction accordingly.
- The types of transactions that can be signed with the key of the corresponding Role seem to be associated with each 'TxType' below.
  (e.g RoleAccountUpdate(Role) : AccountUpdate(TxType)
         RoleTransaction(Role) :  ValueTransfer(TxType))
```
// Klaytn Type Enumeration
export enum TxType {
  // Basic
  ValueTransfer = 0x08,
  ValueTransferMemo = 0x10,
  AccountUpdate = 0x20,
  SmartContractDeploy = 0x28,
  SmartContractExecution = 0x30,
  Cancel = 0x38,

  // Fee Delegation
  FeeDelegatedValueTransfer = 0x09,
  FeeDelegatedValueTransferMemo = 0x11,
  FeeDelegatedAccountUpdate = 0x21,
  FeeDelegatedSmartContractDeploy = 0x29,
  FeeDelegatedSmartContractExecution = 0x31,
  FeeDelegatedCancel = 0x39,

  // Partial Fee Delegation
  FeeDelegatedValueTransferWithRatio = 0x0a,
  FeeDelegatedValueTransferMemoWithRatio = 0x12,
  FeeDelegatedAccountUpdateWithRatio = 0x22,
  FeeDelegatedSmartContractDeployWithRatio = 0x2a,
  FeeDelegatedSmartContractExecutionWithRatio = 0x32,
  FeeDelegatedCancelWithRatio = 0x3a,
}

```

- Therefore, I will conduct a test to check whether each key performs its role properly by signing the transaction with AccountKeyRoleBased that matches each TxType.

## **Test Cases**
0. Before all tests, set up Role-based Key
```
before(async function () {
        console.log("\n--- Setting Role-based Key ---");
        const pub1 = getPublicKeyFromPrivate(senderRoleTransactionPriv);
        const pub2 = getPublicKeyFromPrivate(senderRoleAccountUpdatePriv);
        const pub3 = getPublicKeyFromPrivate(senderRoleFeePayerPriv);

        const updateTx = {
            type: TxType.AccountUpdate,
            from: senderAddr,
            gasLimit: 100000,
            key: {
                type: AccountKeyType.RoleBased,
                keys: [
                    { type: AccountKeyType.Public, key: pub1 },
                    { type: AccountKeyType.Public, key: pub2 },
                    { type: AccountKeyType.Public, key: pub3 }
                ]
            }
        };

        const signedUpdateTx = await roleAccountUpdate.signTransaction(updateTx);
        const receipt = await web3.eth.sendSignedTransaction(signedUpdateTx.rawTransaction);
        console.log("Account Updated:", receipt);
        assert.isNotNull(receipt.transactionHash, "Account update transaction should succeed");
    });
```

1. Sending a normal transaction with RoleTransaction key
- Signing transactions with 'RoleTransaction' key for 'TxType.ValueTransfer'
```
it("1. Sending a normal transaction with RoleTransaction key", async function () {
        const valueTx = {
            type: TxType.ValueTransfer,
            from: senderAddr,
            to: receiverAddr,
            value: toPeb("0.01"),
            gasLimit: 100000
        };

        const signedTx = await roleTransactionAccount.signTransaction(valueTx);
        const receipt = await web3.eth.sendSignedTransaction(signedTx.rawTransaction);
        console.log("RoleTransaction signedTx:", receipt.transactionHash);
        assert.isNotNull(receipt.transactionHash, "RoleTransaction transaction should succeed");
    });
```

2. Attempting to sign a regular transaction with RoleFeePayer key (failure test):
- Signing transactions with 'RoleFeePayer' key for 'TxType.ValueTransfer'
```
it("2. Attempting to sign a regular transaction with RoleFeePayer key (failure test)", async function () {
        const valueTx = {
            type: TxType.ValueTransfer,
            from: senderAddr,
            to: receiverAddr,
            value: toPeb("0.01"),
            gasLimit: 100000
        };

        try {
            const signedTx = await roleFeePayerAccount.signTransaction(valueTx);
            const receipt = await web3.eth.sendSignedTransaction(signedTx.rawTransaction);
            console.log("Unexpected Success - Transaction Hash:", receipt.transactionHash);
            assert.fail("RoleFeePayer key should not sign a regular transaction.");
        } catch (error: any) {
            console.log("Expected Error (RoleFeePayer):", error.message);
            assert.isTrue(true, "Error occurred as expected");
        }
    });
```

3. Fee Delegated transaction signed by RoleFeePayer key (should succeed):
- Signing transactions with 'RoleFeePayer' key for 'TxType.FeeDelegatedValueTransfer'
```
it("3. Fee Delegated transaction signed by RoleFeePayer key (should succeed)", async function () {
        console.log("\n--- Checking Balances ---");
        const senderBalance = await checkBalance(senderAddr);
        const feePayerBalance = await checkBalance(roleFeePayerAccount.address);

        assert.isAbove(senderBalance, 0.01, "Sender account must have enough balance.");
        assert.isAbove(feePayerBalance, 0.01, "FeePayer account must have enough balance.");

        const feeDelegatedTx = {
            type: TxType.FeeDelegatedValueTransfer,
            from: senderAddr,
            to: receiverAddr,
            value: toPeb("0.01"),
            gasLimit: 100000
        };

        const signedTx = await roleFeePayerAccount.signTransaction(feeDelegatedTx);
        const receipt = await web3.eth.sendSignedTransaction(signedTx.rawTransaction);
        console.log("Fee Delegated Transaction Hash:", receipt.transactionHash);
        assert.isNotNull(receipt.transactionHash, "RoleFeePayer transaction should succeed");
    });
```

4. Attempting to sign Fee Delegated transaction with RoleTransaction key (failure test):
- Signing transactions with 'RoleTransaction ' key for 'TxType.FeeDelegatedValueTransfer'
```
it("4. Attempting to sign Fee Delegated transaction with RoleTransaction key (should fail)", async function () {
        console.log("\n--- Checking Balances ---");
        const senderBalance = await checkBalance(senderAddr);

        assert.isAbove(senderBalance, 0.01, "Sender account should have sufficient balance");

        const feeDelegatedTx = {
            type: TxType.FeeDelegatedValueTransfer,
            from: senderAddr,
            to: receiverAddr,
            value: toPeb("0.01"),
            gasLimit: 100000
        };

        try {
            const signedTx = await roleTransactionAccount.signTransaction(feeDelegatedTx);
            const receipt = await web3.eth.sendSignedTransaction(signedTx.rawTransaction);
            console.log("Unexpected Success - Transaction Hash:", receipt.transactionHash);
            assert.fail("RoleTransaction key should not sign Fee Delegated transactions");
        } catch (error: any) {
            console.log("Expected Error (RoleTransaction as FeePayer):", error.message);
            assert.isTrue(true, "Error occurred as expected");
        }
    });
```

## **Test Results**
![image](https://github.com/user-attachments/assets/1abe1100-d137-4495-a60f-5902391463e9)
1. Sending a normal transaction with RoleTransaction key
- Success, by signing with a key (RoleTransaction) that matches the role of the transaction (TxType.ValueTransfer)

2. Attempting to sign a regular transaction with RoleFeePayer key (failure test):
- Success, the transaction (TxType.ValueTransfer) is not signed with a key (RoleFeePayer) that matches the role of the transaction (TxType.ValueTransfer) (expected result)

3. Fee Delegated transaction signed by RoleFeePayer key (should succeed):
- Failure, An error occurred when the transaction (TxType.FeeDelegatedValueTransfer) must be signed with a key (RoleFeePayer) that matches the role of the transaction to succeed.

4. Attempting to sign Fee Delegated transaction with RoleTransaction key (failure test):
- Success, The expected failure result is due to not signing with a key (RoleTransaction) that matches the role of the transaction (TxType.FeeDelegatedValueTransfer).



## **Test Bug?**
3. Fee Delegated transaction signed by RoleFeePayer key (should succeed):
![image](https://github.com/user-attachments/assets/a01e5389-000d-4dfc-8688-a0b6e969d54b)
- I get an RLP-related error when signing a FeeDelegatedTranscation with RoleFeePayer.