### PR TITLE
feat: add ethers-v6 unit conversion helpers

### DIFF
--- a/ethers-ext/example/v6/accountKey/sign_tx_AccountKeyPublic.js
+++ b/ethers-ext/example/v6/accountKey/sign_tx_AccountKeyPublic.js
@@ -3,7 +3,7 @@
 
 const { ethers } = require("ethers6");
 
-const { Wallet, TxType, parseKlay } = require("@kaiachain/ethers-ext/v6");
+const { Wallet, TxType, parseKaia } = require("@kaiachain/ethers-ext/v6");
 
 const senderAddr = "0xe15cd70a41dfb05e7214004d7d054801b2a2f06b";
 const senderPriv =
@@ -23,7 +23,7 @@ async function main() {
     type: TxType.ValueTransfer,
     from: senderAddr,
     to: recieverAddr,
-    value: parseKlay("0.01").toString(),
+    value: parseKaia("0.01"),
   };
 
   const populatedTx = await newWallet.populateTransaction(tx);

--- a/ethers-ext/example/v6/accountKey/sign_tx_AccountKeyRoleBased.js
+++ b/ethers-ext/example/v6/accountKey/sign_tx_AccountKeyRoleBased.js
@@ -3,7 +3,7 @@
 
 const { ethers } = require("ethers6");
 
-const { Wallet, TxType, parseKlay } = require("@kaiachain/ethers-ext/v6");
+const { Wallet, TxType, parseKaia } = require("@kaiachain/ethers-ext/v6");
 
 const senderAddr = "0x5bd2fb3c21564c023a4a735935a2b7a238c4ccea";
 const senderPriv =
@@ -27,7 +27,7 @@ async function main() {
     type: TxType.ValueTransfer,
     from: senderAddr,
     to: recieverAddr,
-    value: parseKlay("0.01").toString(),
+    value: parseKaia("0.01"),
     gasLimit: 100000,
   };
 

--- a/ethers-ext/example/v6/accountKey/sign_tx_AccountKeyWeightedMultiSig.js
+++ b/ethers-ext/example/v6/accountKey/sign_tx_AccountKeyWeightedMultiSig.js
@@ -7,7 +7,7 @@ const {
   Wallet,
   TxType,
   AccountKeyType,
-  parseKlay,
+  parseKaia,
 } = require("@kaiachain/ethers-ext/v6");
 
 const senderAddr = "0x82c6a8d94993d49cfd0c1d30f0f8caa65782cc7e";
@@ -34,7 +34,7 @@ async function main() {
     type: TxType.ValueTransfer,
     from: senderAddr,
     to: recieverAddr,
-    value: parseKlay("0.01").toString(),
+    value: parseKaia("0.01"),
     gasLimit: 100000,
   };
 

--- a/ethers-ext/example/v6/browser-react/src/components/KlaytnFeeDelVT.tsx
+++ b/ethers-ext/example/v6/browser-react/src/components/KlaytnFeeDelVT.tsx
@@ -1,7 +1,8 @@
-import { useState } from 'react';
-import { Account } from '../types';
-import { doSignTx } from '../util';
-import { TxType, parseKlay } from '@kaiachain/js-ext-core';
+import { useState } from "react";
+import { Account } from "../types";
+import { doSignTx } from "../util";
+import { TxType } from "@kaiachain/js-ext-core";
+import { parseKaia } from "@kaiachain/ethers-ext/v6";
 
 type Props = {
   account: Account;
@@ -16,7 +17,7 @@ function KlaytnFeeDelVT({ account }: Props) {
     const tx = {
       type: TxType.FeeDelegatedValueTransfer,
       to: e.target.to.value,
-      value:  parseKlay(e.target.amount.value).toString(),
+      value: parseKaia(e.target.amount.value),
     };
 
     try {
@@ -30,14 +31,29 @@ function KlaytnFeeDelVT({ account }: Props) {
   return (
     <div className="menu-component">
       <form onSubmit={handleSubmit}>
-        <p>To: <input type="text" name="to" defaultValue={account.address}></input></p>
-        <p>Value: <input type="text" name="amount" defaultValue="0.01"></input></p>
-        <p><input type="submit"></input></p>
+        <p>
+          To:{" "}
+          <input type="text" name="to" defaultValue={account.address}></input>
+        </p>
+        <p>
+          Value: <input type="text" name="amount" defaultValue="0.01"></input>
+        </p>
+        <p>
+          <input type="submit"></input>
+        </p>
       </form>
-      { txhash? <a target="_blank" href={txhash} rel="noreferrer">{txhash}</a> : null }
-    { error? <text><b style={{ color: "red" }}>{error}</b></text> : null }
-  </div>
-);
-};
+      {txhash ? (
+        <a target="_blank" href={txhash} rel="noreferrer">
+          {txhash}
+        </a>
+      ) : null}
+      {error ? (
+        <text>
+          <b style={{ color: "red" }}>{error}</b>
+        </text>
+      ) : null}
+    </div>
+  );
+}
 
 export default KlaytnFeeDelVT;

--- a/ethers-ext/example/v6/browser-react/src/components/KlaytnVT.tsx
+++ b/ethers-ext/example/v6/browser-react/src/components/KlaytnVT.tsx
@@ -1,8 +1,8 @@
-import { useState } from 'react';
-import { Account } from '../types';
-import { doSendTx } from '../util';
-import { TxType, parseKlay } from '@kaiachain/js-ext-core';
-
+import { useState } from "react";
+import { Account } from "../types";
+import { doSendTx } from "../util";
+import { TxType } from "@kaiachain/js-ext-core";
+import { parseKaia } from "@kaiachain/ethers-ext/v6";
 type Props = {
   account: Account;
 };
@@ -16,7 +16,7 @@ function KlaytnVT({ account }: Props) {
     const tx = {
       type: TxType.ValueTransfer,
       to: e.target.to.value,
-      value: parseKlay(e.target.amount.value).toString(),
+      value: parseKaia(e.target.amount.value),
     };
 
     try {
@@ -30,14 +30,29 @@ function KlaytnVT({ account }: Props) {
   return (
     <div className="menu-component">
       <form onSubmit={handleSubmit}>
-        <p>To: <input type="text" name="to" defaultValue={account.address}></input></p>
-        <p>Value: <input type="text" name="amount" defaultValue="0.01"></input></p>
-        <p><input type="submit"></input></p>
+        <p>
+          To:{" "}
+          <input type="text" name="to" defaultValue={account.address}></input>
+        </p>
+        <p>
+          Value: <input type="text" name="amount" defaultValue="0.01"></input>
+        </p>
+        <p>
+          <input type="submit"></input>
+        </p>
       </form>
-      { txhash? <a target="_blank" href={txhash} rel="noreferrer">{txhash}</a> : null }
-    { error? <text><b style={{ color: "red" }}>{error}</b></text> : null }
-  </div>
-);
-};
+      {txhash ? (
+        <a target="_blank" href={txhash} rel="noreferrer">
+          {txhash}
+        </a>
+      ) : null}
+      {error ? (
+        <text>
+          <b style={{ color: "red" }}>{error}</b>
+        </text>
+      ) : null}
+    </div>
+  );
+}
 
 export default KlaytnVT;

--- a/ethers-ext/example/v6/browser-react/src/components/LegacyVT.tsx
+++ b/ethers-ext/example/v6/browser-react/src/components/LegacyVT.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { Account } from '../types';
 import { doSendTx } from '../util';
-import { parseKlay } from '@kaiachain/ethers-ext/v6';
+import { parseKaia } from '@kaiachain/ethers-ext/v6';
 
 type Props = {
   account: Account;
@@ -14,7 +14,7 @@ function LegacyVT({ account }: Props) {
   async function handleSubmit(e: any) {
     e.preventDefault();
     const toAddr = e.target.to.value;
-    const valuePeb = parseKlay(e.target.amount.value).toString();
+    const valuePeb = parseKaia(e.target.amount.value);
     const tx = {
       to: toAddr,
       value: valuePeb,

--- a/ethers-ext/example/v6/transactions/Basic_08_TxTypeValueTransfer.js
+++ b/ethers-ext/example/v6/transactions/Basic_08_TxTypeValueTransfer.js
@@ -3,7 +3,7 @@
 
 const ethers = require("ethers6");
 
-const { Wallet, TxType, parseKlay } = require("@kaiachain/ethers-ext/v6");
+const { Wallet, TxType, parseKaia } = require("@kaiachain/ethers-ext/v6");
 
 const recieverAddr = "0xc40b6909eb7085590e1c26cb3becc25368e249e9";
 const senderAddr = "0xa2a8854b1802d8cd5de631e690817c253d6a9153";
@@ -20,7 +20,7 @@ async function main() {
     type: TxType.ValueTransfer,
     from: senderAddr,
     to: recieverAddr,
-    value: parseKlay("0.01").toString(),
+    value: parseKaia("0.01"),
   };
 
   const sentTx = await wallet.sendTransaction(tx);

--- a/ethers-ext/example/v6/transactions/Basic_10_TxTypeValueTransferMemo.js
+++ b/ethers-ext/example/v6/transactions/Basic_10_TxTypeValueTransferMemo.js
@@ -3,7 +3,7 @@
 
 const ethers = require("ethers6");
 
-const { Wallet, TxType, parseKlay } = require("@kaiachain/ethers-ext/v6");
+const { Wallet, TxType, parseKaia } = require("@kaiachain/ethers-ext/v6");
 
 const recieverAddr = "0xc40b6909eb7085590e1c26cb3becc25368e249e9";
 const senderAddr = "0xa2a8854b1802d8cd5de631e690817c253d6a9153";
@@ -20,7 +20,7 @@ async function main() {
     type: TxType.ValueTransferMemo,
     from: senderAddr,
     to: recieverAddr,
-    value: parseKlay("0.01").toString(),
+    value: parseKaia("0.01"),
     data: "0x1234567890",
   };
 

--- a/ethers-ext/example/v6/transactions/FeeDel_09_TxTypeFeeDelegatedValueTransfer.js
+++ b/ethers-ext/example/v6/transactions/FeeDel_09_TxTypeFeeDelegatedValueTransfer.js
@@ -3,7 +3,7 @@
 
 const ethers = require("ethers6");
 
-const { Wallet, TxType, parseKlay } = require("@kaiachain/ethers-ext/v6");
+const { Wallet, TxType, parseKaia } = require("@kaiachain/ethers-ext/v6");
 
 const senderAddr = "0xa2a8854b1802d8cd5de631e690817c253d6a9153";
 const senderPriv =
@@ -23,7 +23,7 @@ async function main() {
   const tx = {
     type: TxType.FeeDelegatedValueTransfer,
     to: recieverAddr,
-    value: parseKlay("0.01").toString(),
+    value: parseKaia("0.01"),
     from: senderAddr,
   };
 

--- a/ethers-ext/example/v6/transactions/FeeDel_11_TxTypeFeeDelegatedValueTransferMemo.js
+++ b/ethers-ext/example/v6/transactions/FeeDel_11_TxTypeFeeDelegatedValueTransferMemo.js
@@ -3,7 +3,7 @@
 
 const ethers = require("ethers6");
 
-const { Wallet, TxType, parseKlay } = require("@kaiachain/ethers-ext/v6");
+const { Wallet, TxType, parseKaia } = require("@kaiachain/ethers-ext/v6");
 
 const senderAddr = "0xa2a8854b1802d8cd5de631e690817c253d6a9153";
 const senderPriv =
@@ -24,7 +24,7 @@ async function main() {
     type: TxType.FeeDelegatedValueTransferMemo,
     from: senderAddr,
     to: recieverAddr,
-    value: parseKlay("0.01").toString(),
+    value: parseKaia("0.01"),
     data: "0x1234567890",
   };
 

--- a/ethers-ext/example/v6/transactions/FeeDel_39_TxTypeFeeDelegatedCancel.js
+++ b/ethers-ext/example/v6/transactions/FeeDel_39_TxTypeFeeDelegatedCancel.js
@@ -3,7 +3,7 @@
 
 const ethers = require("ethers6");
 
-const { Wallet, TxType, parseKlay } = require("@kaiachain/ethers-ext/v6");
+const { Wallet, TxType, parseKaia } = require("@kaiachain/ethers-ext/v6");
 
 const senderAddr = "0xa2a8854b1802d8cd5de631e690817c253d6a9153";
 const senderPriv =

--- a/ethers-ext/example/v6/transactions/PartialFeeDel_0a_TxTypeFeeDelegatedValueTransferWithRatio.js
+++ b/ethers-ext/example/v6/transactions/PartialFeeDel_0a_TxTypeFeeDelegatedValueTransferWithRatio.js
@@ -3,7 +3,7 @@
 
 const ethers = require("ethers6");
 
-const { Wallet, TxType, parseKlay } = require("@kaiachain/ethers-ext/v6");
+const { Wallet, TxType, parseKaia } = require("@kaiachain/ethers-ext/v6");
 
 const senderAddr = "0xa2a8854b1802d8cd5de631e690817c253d6a9153";
 const senderPriv =
@@ -23,7 +23,7 @@ async function main() {
   const tx = {
     type: TxType.FeeDelegatedValueTransferWithRatio,
     to: recieverAddr,
-    value: parseKlay("0.01").toString(),
+    value: parseKaia("0.01"),
     from: senderAddr,
     feeRatio: 30,
   };

--- a/ethers-ext/example/v6/transactions/PartialFeeDel_12_TxTypeFeeDelegatedValueTransferMemoWithRatio.js
+++ b/ethers-ext/example/v6/transactions/PartialFeeDel_12_TxTypeFeeDelegatedValueTransferMemoWithRatio.js
@@ -3,7 +3,7 @@
 
 const ethers = require("ethers6");
 
-const { Wallet, TxType, parseKlay } = require("@kaiachain/ethers-ext/v6");
+const { Wallet, TxType, parseKaia } = require("@kaiachain/ethers-ext/v6");
 
 const senderAddr = "0xa2a8854b1802d8cd5de631e690817c253d6a9153";
 const senderPriv =
@@ -24,7 +24,7 @@ async function main() {
     type: TxType.FeeDelegatedValueTransferMemoWithRatio,
     from: senderAddr,
     to: recieverAddr,
-    value: parseKlay("0.01").toString(),
+    value: parseKaia("0.01"),
     data: "0x1234567890",
     feeRatio: 30,
   };

--- a/ethers-ext/example/v6/transactions/PartialFeeDel_3a_TxTypeFeeDelegatedCancelWithRatio.js
+++ b/ethers-ext/example/v6/transactions/PartialFeeDel_3a_TxTypeFeeDelegatedCancelWithRatio.js
@@ -3,7 +3,7 @@
 
 const ethers = require("ethers6");
 
-const { Wallet, TxType, parseKlay } = require("@kaiachain/ethers-ext/v6");
+const { Wallet, TxType, parseKaia } = require("@kaiachain/ethers-ext/v6");
 
 const senderAddr = "0xa2a8854b1802d8cd5de631e690817c253d6a9153";
 const senderPriv =

--- a/ethers-ext/example/v6/transactions/legacy.js
+++ b/ethers-ext/example/v6/transactions/legacy.js
@@ -3,7 +3,7 @@
 
 const ethers = require("ethers6");
 
-const { Wallet, parseKlay } = require("@kaiachain/ethers-ext/v6");
+const { Wallet, parseKaia } = require("@kaiachain/ethers-ext/v6");
 
 const recieverAddr = "0xc40b6909eb7085590e1c26cb3becc25368e249e9";
 const senderAddr = "0xa2a8854b1802d8cd5de631e690817c253d6a9153";
@@ -22,7 +22,7 @@ async function main() {
     // here, type will be 2 because no gas-related fields are set.
     from: senderAddr,
     to: recieverAddr,
-    value: parseKlay("0.01").toString(),
+    value: parseKaia("0.01"),
   };
 
   const sentTx = await wallet.sendTransaction(tx);

--- a/ethers-ext/example/v6/utils/util.js
+++ b/ethers-ext/example/v6/utils/util.js
@@ -4,9 +4,9 @@ const {
   getCompressedPublicKey,
   getSignatureTuple,
   formatKlayUnits,
-  parseKlayUnits,
+  parseKaiaUnits,
   formatKlay,
-  parseKlay,
+  parseKaia,
 } = require("@kaiachain/ethers-ext/v6");
 
 async function main() {
@@ -53,9 +53,9 @@ async function main() {
   console.log("transfer amount in klay =", formatKlay("1230000000000000000"));
   console.log(
     "example gas price in peb =",
-    parseKlayUnits("50", "ston").toString()
+    parseKaiaUnits("50", "ston")
   );
-  console.log("transfer amount in peb =", parseKlay("9.87").toString());
+  console.log("transfer amount in peb =", parseKaia("9.87"));
 }
 
 main();

--- a/ethers-ext/src/index.ts
+++ b/ethers-ext/src/index.ts
@@ -1,6 +1,6 @@
 // Pass-through js-ext-core exports
 export * from "@kaiachain/js-ext-core/util";
-export * from './v5'
+export * from "./v5";
 
 import * as v5 from "./v5";
 import * as v6 from "./v6";

--- a/ethers-ext/src/v6/index.ts
+++ b/ethers-ext/src/v6/index.ts
@@ -21,3 +21,8 @@ export const providers = {
   JsonRpcProvider,
   Web3Provider,
 };
+export {
+  parseKaia,
+  parseKaiaUnits,
+  parseUnits,
+} from "@kaiachain/js-ext-core/ethers-v6";

--- a/js-ext-core/package.json
+++ b/js-ext-core/package.json
@@ -12,6 +12,10 @@
     "./util": {
       "types": "./dist/util/index.d.ts",
       "default": "./dist/util/index.js"
+    },
+    "./ethers-v6": {
+      "types": "./dist/ethers-v6/index.d.ts",
+      "default": "./dist/ethers-v6/index.js"
     }
   },
   "files": [

--- a/js-ext-core/src/ethers-v6/index.ts
+++ b/js-ext-core/src/ethers-v6/index.ts
@@ -1,0 +1,1 @@
+export { parseKaia, parseKaiaUnits, parseUnits } from "./unit";

--- a/js-ext-core/src/ethers-v6/unit.ts
+++ b/js-ext-core/src/ethers-v6/unit.ts
@@ -6,21 +6,34 @@ import {
   parseUnits as parseUnitsBase,
 } from "../util";
 /**
- * Convert KAIA to peb
+ * Convert kaia to kei
  *
- * @param   kaia  string number of KAIA unit
- * @returns equivalent value in peb.
+ * @param   kaia  string number in kaia unit
+ * @returns equivalent value in kei.
  */
 export function parseKaia(kaia: string): bigint {
   return parseKaiaBase(kaia).toBigInt();
 }
-
+/**
+ * Convert Kaia's units to kei
+ *
+ * @param   value  string number of unit
+ * @param unitName name of unit to convert (kei/gkei/kaia)
+ * @returns equivalent value in peb.
+ */
 export function parseKaiaUnits(
   value: string,
   unitName?: string | BigNumberish
 ): bigint {
   return parseKaiaUnitsBase(value, unitName).toBigInt();
 }
+/**
+ * Convert Kaia's units to kei
+ *
+ * @param   value  string number of unit
+ * @param unitName name of unit to convert (kei/gkei/kaia)
+ * @returns equivalent value in peb.
+ */
 export function parseUnits(
   value: string,
   unitName?: string | BigNumberish

--- a/js-ext-core/src/ethers-v6/unit.ts
+++ b/js-ext-core/src/ethers-v6/unit.ts
@@ -1,0 +1,29 @@
+import { BigNumberish } from "@ethersproject/bignumber";
+
+import {
+  parseKaia as parseKaiaBase,
+  parseKaiaUnits as parseKaiaUnitsBase,
+  parseUnits as parseUnitsBase,
+} from "../util";
+/**
+ * Convert KAIA to peb
+ *
+ * @param   kaia  string number of KAIA unit
+ * @returns equivalent value in peb.
+ */
+export function parseKaia(kaia: string): bigint {
+  return parseKaiaBase(kaia).toBigInt();
+}
+
+export function parseKaiaUnits(
+  value: string,
+  unitName?: string | BigNumberish
+): bigint {
+  return parseKaiaUnitsBase(value, unitName).toBigInt();
+}
+export function parseUnits(
+  value: string,
+  unitName?: string | BigNumberish
+): bigint {
+  return parseUnitsBase(value, unitName).toBigInt();
+}


### PR DESCRIPTION
1. This PR add kaia unit conversion that support bigint for ethers-ext/v6.
2. Included functions:
- `parseKaia`
- `parseUnits`
- `parseKaiaUnits`
- Examples for ethers-ext/v6 is updated.