### PR TITLE
feat: add ethers-v6 support

### DIFF
--- a/js-ext-core/package.json
+++ b/js-ext-core/package.json
@@ -12,6 +12,10 @@
     "./util": {
       "types": "./dist/util/index.d.ts",
       "default": "./dist/util/index.js"
+    },
+    "./ethers-v6": {
+      "types": "./dist/ethers-v6/index.d.ts",
+      "default": "./dist/ethers-v6/index.js"
     }
   },
   "files": [

--- a/js-ext-core/src/ethers-v6/index.ts
+++ b/js-ext-core/src/ethers-v6/index.ts
@@ -1,0 +1,1 @@
+export { parseKaia, parseKaiaUnits, parseUnits } from "./unit";

--- a/js-ext-core/src/ethers-v6/unit.ts
+++ b/js-ext-core/src/ethers-v6/unit.ts
@@ -1,0 +1,42 @@
+import { BigNumberish } from "@ethersproject/bignumber";
+
+import {
+  parseKaia as parseKaiaBase,
+  parseKaiaUnits as parseKaiaUnitsBase,
+  parseUnits as parseUnitsBase,
+} from "../util";
+/**
+ * Convert kaia to kei
+ *
+ * @param   kaia  string number in kaia unit
+ * @returns equivalent value in kei.
+ */
+export function parseKaia(kaia: string): bigint {
+  return parseKaiaBase(kaia).toBigInt();
+}
+/**
+ * Convert Kaia's units to kei
+ *
+ * @param   value  string number of unit
+ * @param unitName name of unit to convert (kei/gkei/kaia)
+ * @returns equivalent value in peb.
+ */
+export function parseKaiaUnits(
+  value: string,
+  unitName?: string | BigNumberish
+): bigint {
+  return parseKaiaUnitsBase(value, unitName).toBigInt();
+}
+/**
+ * Convert Kaia's units to kei
+ *
+ * @param   value  string number of unit
+ * @param unitName name of unit to convert (kei/gkei/kaia)
+ * @returns equivalent value in peb.
+ */
+export function parseUnits(
+  value: string,
+  unitName?: string | BigNumberish
+): bigint {
+  return parseUnitsBase(value, unitName).toBigInt();
+}


### PR DESCRIPTION
1. Add ethers-v6 unit conversion support.
2. Includes:
 - parseKaia
 - parseKaiaUnits
 - parseUnits