### PR TITLE
feat: update readme for javascript sdk

### DIFF
--- a/ethers-ext/README.md
+++ b/ethers-ext/README.md
@@ -15,6 +15,9 @@ Ethers.js Extension for Kaia offers:
 > **_NOTE:_**
 > If the import path has no version sub-path (`@kaiachain/ethers-ext`), ethers v5 will be used by default.
 
+> **_NOTE:_**
+> @kaiachain/ethers-ext@^1.2.0 recommends node 22 or later if you have issues with ES Module resolution.
+
 - **Don't**: Mixing ethers v6 and ethers-ext for ethers v5
 
   ```js

--- a/js-ext-core/README.md
+++ b/js-ext-core/README.md
@@ -2,6 +2,9 @@
 
 Sub-components of Klaytn JavaScript SDKs.
 
+> **_NOTE:_**
+> @kaiachain/js-ext-core@^1.2.0 recommends node 22 or later if you have issues with ES Module resolution.
+
 For dApp developers and blockchain users, use the SDKs like [@kaiachain/ethers-ext](https://www.npmjs.com/package/@kaiachain/ethers-ext) and [@kaiachain/web3js-ext](https://www.npmjs.com/package/@kaiachain/web3js-ext).
 
 - `FieldSetFactory` to easily build custom RLP-encodable types

--- a/web3js-ext/README.md
+++ b/web3js-ext/README.md
@@ -6,6 +6,9 @@ Web3.js Extension for kaia offers:
 
 ## Install
 
+> **_NOTE:_**
+> @kaiachain/web3js-ext@^1.2.0 recommends node 22 or later if you have issues with ES Module resolution.
+
 ### Node.js
 
 - Install

--- a/web3js-ext/package-lock.json
+++ b/web3js-ext/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@kaiachain/web3js-ext",
-    "version": "1.1.1",
+    "version": "1.2.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@kaiachain/web3js-ext",
-            "version": "1.1.1",
+            "version": "1.2.0",
             "license": "MIT",
             "dependencies": {
                 "@kaiachain/js-ext-core": "^1.2.0",
@@ -16,6 +16,7 @@
                 "web3": "^4.1.0"
             },
             "devDependencies": {
+                "@kaiachain/web3js-ext": "file:./",
                 "@types/chai": "^4.3.4",
                 "@types/chai-as-promised": "^7.1.5",
                 "@types/lodash": "^4.14.192",
@@ -32,6 +33,9 @@
                 "typescript": "^5.0.4",
                 "webpack": "^5.89.0",
                 "webpack-cli": "^5.1.4"
+            },
+            "engines": {
+                "node": ">=22.0.0"
             }
         },
         "node_modules/@aashutoshrathi/word-wrap": {
@@ -1217,6 +1221,10 @@
                 "elliptic": "^6.5.4",
                 "lodash-es": "^4.17.21"
             }
+        },
+        "node_modules/@kaiachain/web3js-ext": {
+            "resolved": "",
+            "link": true
         },
         "node_modules/@kaiachain/web3rpc": {
             "version": "1.2.0",


### PR DESCRIPTION
- From version 1.2.0, `ethers-ext`, `web3js-ext` and `js-ext-core` recommends using node v22 if you are having issues with ES Module resolution.