### PR TITLE
refactor: move ethers6 alias to devDependencies

### DIFF
--- a/ethers-ext/package-lock.json
+++ b/ethers-ext/package-lock.json
@@ -29,7 +29,7 @@
         "@ethersproject/web": "^5.7.1",
         "@kaiachain/js-ext-core": "^2.0.0",
         "@kaiachain/web3rpc": "^1.2.1",
-        "ethers6": "npm:ethers@^6.12.1",
+        "ethers": "^6.12.1",
         "lodash": "^4.17.21"
       },
       "devDependencies": {
@@ -45,6 +45,7 @@
         "eslint": "^8.45.0",
         "eslint-plugin-import": "^2.27.5",
         "ethers5": "npm:ethers@^5.7.2",
+        "ethers6": "file:./node_modules/ethers",
         "mocha": "^10.2.0",
         "ts-loader": "^9.5.1",
         "ts-node": "^10.9.1",
@@ -55,6 +56,9 @@
         "webpack-cli": "^5.1.4",
         "webpack-visualizer-plugin2": "^1.1.0"
       }
+    },
+    "../../../../node_modules/ethers": {
+      "extraneous": true
     },
     "node_modules/@aashutoshrathi/word-wrap": {
       "version": "1.2.6",
@@ -2052,7 +2056,8 @@
     "node_modules/@types/node": {
       "version": "18.15.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.13.tgz",
-      "integrity": "sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q=="
+      "integrity": "sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q==",
+      "dev": true
     },
     "node_modules/@types/semver": {
       "version": "7.5.0",
@@ -4031,57 +4036,8 @@
       }
     },
     "node_modules/ethers6": {
-      "name": "ethers",
-      "version": "6.13.1",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.13.1.tgz",
-      "integrity": "sha512-hdJ2HOxg/xx97Lm9HdCWk949BfYqYWpyw4//78SiwOLgASyfrNszfMUNB2joKjvGUdwhHfaiMMFFwacVVoLR9A==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/ethers-io/"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@adraffy/ens-normalize": "1.10.1",
-        "@noble/curves": "1.2.0",
-        "@noble/hashes": "1.3.2",
-        "@types/node": "18.15.13",
-        "aes-js": "4.0.0-beta.5",
-        "tslib": "2.4.0",
-        "ws": "8.17.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/ethers6/node_modules/aes-js": {
-      "version": "4.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
-      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q=="
-    },
-    "node_modules/ethers6/node_modules/ws": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
+      "resolved": "node_modules/ethers",
+      "link": true
     },
     "node_modules/events": {
       "version": "3.3.0",
@@ -6624,11 +6580,6 @@
       "bin": {
         "json5": "lib/cli.js"
       }
-    },
-    "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/tsx": {
       "version": "4.19.2",

--- a/ethers-ext/package.json
+++ b/ethers-ext/package.json
@@ -67,6 +67,7 @@
     "eslint": "^8.45.0",
     "eslint-plugin-import": "^2.27.5",
     "ethers5": "npm:ethers@^5.7.2",
+    "ethers6": "file:./node_modules/ethers",
     "mocha": "^10.2.0",
     "ts-loader": "^9.5.1",
     "ts-node": "^10.9.1",
@@ -98,7 +99,7 @@
     "@ethersproject/web": "^5.7.1",
     "@kaiachain/web3rpc": "^1.2.1",
     "@kaiachain/js-ext-core": "^2.0.0",
-    "ethers6": "npm:ethers@^6.12.1",
+    "ethers": "^6.12.1",
     "lodash": "^4.17.21"
   }
 }

--- a/ethers-ext/src/v6/accountStore.ts
+++ b/ethers-ext/src/v6/accountStore.ts
@@ -4,7 +4,7 @@ import {
   computeAddress,
   JsonRpcProvider,
   SigningKey,
-} from "ethers6";
+} from "ethers";
 
 import { HexStr } from "@kaiachain/js-ext-core";
 

--- a/ethers-ext/src/v6/keystore.ts
+++ b/ethers-ext/src/v6/keystore.ts
@@ -3,7 +3,7 @@ import {
   decryptKeystoreJson,
   decryptKeystoreJsonSync,
   getAddress,
-} from "ethers6";
+} from "ethers";
 import _ from "lodash";
 
 import { isKIP3Json, splitKeystoreKIP3 } from "@kaiachain/js-ext-core";

--- a/ethers-ext/src/v6/provider.ts
+++ b/ethers-ext/src/v6/provider.ts
@@ -4,7 +4,7 @@ import {
   JsonRpcProvider as EthersJsonRpcProvider,
   BrowserProvider as EthersWeb3Provider,
   assert,
-} from "ethers6";
+} from "ethers";
 
 import { asyncOpenApi, AsyncNamespaceApi } from "@kaiachain/js-ext-core";
 import {

--- a/ethers-ext/src/v6/signer.ts
+++ b/ethers-ext/src/v6/signer.ts
@@ -16,7 +16,7 @@ import {
   ProgressCallback,
   keccak256,
   assert,
-} from "ethers6";
+} from "ethers";
 import _ from "lodash";
 
 import {

--- a/ethers-ext/src/v6/txutil.ts
+++ b/ethers-ext/src/v6/txutil.ts
@@ -8,7 +8,7 @@ import {
   resolveAddress,
   Transaction,
   assert,
-} from "ethers6";
+} from "ethers";
 import _ from "lodash";
 
 import {

--- a/ethers-ext/src/v6/types.ts
+++ b/ethers-ext/src/v6/types.ts
@@ -1,4 +1,4 @@
-import { TransactionRequest as EthersTransactionRequest } from "ethers6";
+import { TransactionRequest as EthersTransactionRequest } from "ethers";
 export type EthersExternalProvider = {
   isMetaMask?: boolean;
   isStatus?: boolean;


### PR DESCRIPTION
- Refactor ethers 6 alias to devDependencies which make examples of v6 still import ethers6 while the published package to npm will have no alias dependencies.