### PR TITLE
ethers: Update gasless example

### DIFF
--- a/ethers-ext/example/README.md
+++ b/ethers-ext/example/README.md
@@ -1,10 +1,11 @@
 # ethers-ext examples
 
-- [accountKey](./accountKey) Klaytn AccountKey types
-- [browser-html](./browser-html) Browser extension wallets (e.g. Kaikas) interaction in plain HTML
-- [browser-react](./browser-react) Browser extension wallets (e.g. Kaikas) interaction in React.js
-- [contracts](./contracts) Smart contract usage
-- [rpc](./rpc) JSON-RPC wrappers
-- [transactions](./transactions) Klaytn transaction types
-- [util](./util) Utility functions
+- [accountKey](./v6/accountKey) Klaytn AccountKey types
+- [browser-html](./v6/browser-html) Browser extension wallets (e.g. Kaikas) interaction in plain HTML
+- [browser-react](./v6/browser-react) Browser extension wallets (e.g. Kaikas) interaction in React.js
+- [contracts](./v6/contracts) Smart contract usage
+- [gasless](./v6/gasless) KIP-247 gasless swap usage
+- [rpc](./v6/rpc) JSON-RPC wrappers
+- [transactions](./v6/transactions) Klaytn transaction types
+- [utils](./v6/utils) Utility functions
 

--- a/ethers-ext/example/v6/gasless/gasless.js
+++ b/ethers-ext/example/v6/gasless/gasless.js
@@ -65,14 +65,14 @@ async function sendGaslessTx(appTxFee, slippage) {
       tokenAddress,
       gsr.address
     );
-    
+
     const approveResult = await wallet.sendTransaction(approveTx);
     console.log(`Approve transaction hash: ${approveResult.hash}`);
-    
+
     console.log("Waiting for approval confirmation...");
     await approveResult.wait();
     console.log("Approval transaction confirmed");
-    
+
     amountRepay = gasless.getAmountRepay(true, gasPriceGkei);
     console.log(`Amount to repay (with approval): ${ethers.formatUnits(amountRepay, 18)}`);
   } else {
@@ -119,16 +119,16 @@ async function sendGaslessTx(appTxFee, slippage) {
     amountRepay,
     true
   );
-  
+
   console.log("\nSending swap transaction...");
   try {
     const swapResult = await wallet.sendTransaction(swapTx);
     console.log(`Swap transaction hash: ${swapResult.hash}`);
-    
+
     console.log("Waiting for transaction receipt...");
     const receipt = await swapResult.wait();
     console.log("Transaction confirmed:", receipt.blockNumber);
-    
+
     return swapResult.hash;
   } catch (error) {
     console.error("Error in sending swap transaction:", error);

--- a/ethers-ext/example/v6/gasless/gasless.js
+++ b/ethers-ext/example/v6/gasless/gasless.js
@@ -2,155 +2,126 @@ const ethers = require("ethers6");
 
 const { Wallet, gasless } = require("@kaiachain/ethers-ext/v6");
 
-// Replace with actual token address
-const tokenAddress = "0x8ebc32c078f5ecc8406ddDC785c8F0e2490C1081";
+// Replace with ERC20 token address to be spent
+//const tokenAddr = "0xcB00BA2cAb67A3771f9ca1Fa48FDa8881B457750"; // Kairos:TEST token
+const tokenAddr = "0x8ebc32c078f5ecc8406ddDC785c8F0e2490C1081";
 // Replace with your wallet address and private key
-const senderAddr = "0x3A60cD51359485000f9058241D928631E88B0d09";
-const senderPriv = "0x4fbe872c6e55831a7a2ad9c52d555911b198cffa27a0a287d015e31e4e327db7";
+const senderAddr = "0xa0Ee7A142d267C1f36714E4a8F75612F20a79720";
+const senderPriv = "0x2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6";
 
-const provider = new ethers.JsonRpcProvider("http://127.0.0.1:8559");
+//const provider = new ethers.JsonRpcProvider("https://public-en-kairos.node.kaia.io");
+const provider = new ethers.JsonRpcProvider("http://localhost:8559");
 const wallet = new Wallet(senderPriv, provider);
 
 const ERC20_ABI = [
+  "function decimals() view returns (uint8)",
+  "function symbol() view returns (string)",
   "function allowance(address owner, address spender) view returns (uint256)",
   "function balanceOf(address owner) view returns (uint256)"
 ];
 
-const ROUTER_ABI = [
-  "function getAmountsOut(uint amountIn, address[] memory path) view returns (uint[] memory amounts)"
-];
+// senderAddr wants to swap the ERC20 token for at least 1.0 KAIA so she can execute the AppTx.
+async function main() {
+  const appTxFee = ethers.parseEther("1.0").toString(); // 1.0 KAIA
 
-// WKAIA address - this should match your local deployment
-const WKAIA_ADDRESS = "0x75Ec3c04DA63bE95Ec9876Aca967D79A1c74e2cf"; // Using GSR address as placeholder
-const UNISWAP_ROUTER_ADDRESS = "0xcB148BDB400Fd9eDC955B2c8c6a3fb7677e9DeE8"; // UniswapV2Router02 address
+  // Query the environment
+  const token = new ethers.Contract(tokenAddr, ERC20_ABI, provider);
+  const tokenSymbol = await token.symbol();
+  const tokenDecimals = await token.decimals();
+  console.log(`Using token at address: ${tokenAddr}`);
 
-const swapAmount = ethers.parseEther("1.0").toString();
-
-async function sendGaslessTx(appTxFee, slippage) {
-  console.log(`Sending gasless transaction with appTxFee=${appTxFee} and slippage=${slippage}%`);
-
-  const token = new ethers.Contract(tokenAddress, ERC20_ABI, wallet);
-  console.log(`Using token at address: ${tokenAddress}`);
+  console.log(`\nInitial balance of the sender ${senderAddr}`);
+  console.log(`- ${ethers.formatEther(await provider.getBalance(senderAddr))} KAIA`);
+  console.log(`- ${ethers.formatUnits(await token.balanceOf(senderAddr), tokenDecimals)} ${tokenSymbol}`);
 
   const network = await provider.getNetwork();
   const chainId = Number(network.chainId);
-  console.log(`Connected to chain ID: ${chainId}`);
+  const router = await gasless.getGaslessSwapRouter(provider, chainId, "0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9");
+  const routerAddr = await router.getAddress();
+  const commissionRate = Number(await router.commissionRate());
+  console.log(`\nGaslessSwapRouter address: ${routerAddr}`);
+  console.log(`- The token is supported: ${await router.isTokenSupported(tokenAddr)}`);
+  console.log(`- Commission rate: ${commissionRate} bps`);
 
-  const gsr = await gasless.getGaslessSwapRouter(provider, chainId);
-  console.log(`Using gasless swap router at: ${gsr.address}`);
-
-  console.log("Checking if token is supported...");
-  const isSupported = await gsr.isTokenSupported(tokenAddress);
-  console.log(`Token ${tokenAddress} supported: ${isSupported}`);
-
-  const tokenBalance = await token.balanceOf(senderAddr);
-  console.log(`Token balance: ${ethers.formatUnits(tokenBalance, 18)} tokens`);
-
-  const feeData = await provider.getFeeData();
-  const gasPriceGkei = Number(feeData.gasPrice) / 1e9;
-
-  const allowance = await token.allowance(senderAddr, gsr.address);
-  console.log(`Current allowance: ${ethers.formatUnits(allowance, 18)}`);
-  console.log(`Required allowance: ${ethers.formatUnits(swapAmount, 18)} tokens`);
-  console.log(`Has sufficient allowance: ${BigInt(allowance) >= BigInt(swapAmount)}`);
-
-  let approveTx = null;
-  let amountRepay;
-
-  if (!(BigInt(allowance) >= BigInt(swapAmount))) {
-    console.log("Approval needed. Generating approve transaction...");
+  // If sender hasn't approved, include ApproveTx first.
+  const allowance = await token.allowance(senderAddr, routerAddr);
+  const approveRequired = (allowance == 0n);
+  const txs = [];
+  if (approveRequired) {
+    console.log("\nAdding ApproveTx because allowance is 0");
     approveTx = await gasless.getApproveTx(
       provider,
       senderAddr,
-      tokenAddress,
-      gsr.address
+      tokenAddr,
+      routerAddr
     );
-
-    const approveResult = await wallet.sendTransaction(approveTx);
-    console.log(`Approve transaction hash: ${approveResult.hash}`);
-
-    console.log("Waiting for approval confirmation...");
-    await approveResult.wait();
-    console.log("Approval transaction confirmed");
-
-    amountRepay = gasless.getAmountRepay(true, gasPriceGkei);
-    console.log(`Amount to repay (with approval): ${ethers.formatUnits(amountRepay, 18)}`);
+    txs.push(approveTx);
   } else {
-    console.log("No approval needed");
-    amountRepay = gasless.getAmountRepay(false, gasPriceGkei);
-    console.log(`Amount to repay (without approval): ${amountRepay}`);
+    console.log("\nNo ApproveTx needed");
   }
 
-  const commissionRateBasisPoints = await gasless.getCommissionRate(gsr);
-  console.log(`Commission rate: ${commissionRateBasisPoints / 100}%`);
-
-  const uniRouter = new ethers.Contract(UNISWAP_ROUTER_ADDRESS, ROUTER_ABI, provider);
-
-  let swapExpectedOutput;
-  let minAmountOut;
-
-  try {
-    const amountsOut = await uniRouter.getAmountsOut(swapAmount, [tokenAddress, WKAIA_ADDRESS]);
-    swapExpectedOutput = amountsOut[1];
-    console.log(`swapExpectedOutput: ${swapExpectedOutput}`);
-
-    minAmountOut = gasless.getMinAmountOut(amountRepay, appTxFee, commissionRateBasisPoints);
-
-    console.log(`Expected output: ${ethers.formatUnits(swapExpectedOutput, 18)} KAIA`);
-    console.log(`Minimum amount out: ${ethers.formatUnits(minAmountOut, 18)} KAIA`);
-  } catch (error) {
-    console.log("Could not calculate using UniswapV2Router02, falling back to basic calculation");
-    console.log(`err: ${error}`);
-    return;
-  }
-
-  console.log("Calculating optimal amount in with slippage...");
-  const amountIn = await gasless.getAmountIn(gsr, tokenAddress, minAmountOut, slippage);
-  console.log(`Amount in: ${ethers.formatUnits(amountIn, 18)}`);
-
-  console.log("Generating swap transaction...");
+  // - amountRepay (KAIA) is the cost of LendTx, ApproveTx, and SwapTx. The block miner shall fund it first,
+  //   then the sender has to repay from the swap output.
+  // - minAmountOut (KAIA) is the required amount of the swap output. It must be enough to cover the amountRepay
+  //   and pay the commission, still leaving appTxFee.
+  // - amountIn (token) is the amount of the token to be swapped to produce minAmountOut plus slippage.
+  console.log("\nCalculating the amount of the token to be swapped...");
+  const gasPrice = Number((await provider.getFeeData()).gasPrice) / 1e9;
+  console.log(`- gasPrice: ${gasPrice} gkei`);
+  const amountRepay = gasless.getAmountRepay(approveRequired, gasPrice);
+  console.log(`- amountRepay: ${ethers.formatEther(amountRepay)} KAIA`);
+  const minAmountOut = gasless.getMinAmountOut(amountRepay, appTxFee, commissionRate);
+  console.log(`- minAmountOut: ${ethers.formatEther(minAmountOut)} KAIA`);
+  const slippageBps = 50 // 0.5%
+  const amountIn = await gasless.getAmountIn(router, tokenAddr, minAmountOut, slippageBps);
+  console.log(`- amountIn: ${ethers.formatUnits(amountIn, tokenDecimals)} ${tokenSymbol}`);
 
   const swapTx = await gasless.getSwapTx(
     provider,
     senderAddr,
-    tokenAddress,
+    tokenAddr,
     amountIn,
     minAmountOut,
     amountRepay,
-    true
+    !approveRequired
   );
+  txs.push(swapTx);
 
-  console.log("\nSending swap transaction...");
-  try {
-    const swapResult = await wallet.sendTransaction(swapTx);
-    console.log(`Swap transaction hash: ${swapResult.hash}`);
-
-    console.log("Waiting for transaction receipt...");
-    const receipt = await swapResult.wait();
-    console.log("Transaction confirmed:", receipt.blockNumber);
-
-    return swapResult.hash;
-  } catch (error) {
-    console.error("Error in sending swap transaction:", error);
-    console.error("Error details:", JSON.stringify(error, Object.getOwnPropertyNames(error)));
-    return "";
+  console.log("\nSending transactions...");
+  const sentTxs = [];
+  for (const tx of txs) {
+    const sendTx = await wallet.sendTransaction(tx);
+    sentTxs.push(sendTx);
+    console.log(`- Tx sent: ${sendTx.hash}`);
   }
+
+  console.log("\nWaiting for transactions to be mined...");
+  let blockNum = 0;
+  for (const sentTx of sentTxs) {
+    const receipt = await sentTx.wait();
+    console.log(`- Tx mined at block ${receipt.blockNumber}`);
+    blockNum = receipt.blockNumber;
+  }
+
+  console.log("\nListing the block's transactions related to the sender...");
+  const block = await provider.getBlock(blockNum, true);
+  const names = {
+    [senderAddr.toLowerCase()]: "sender",
+    [tokenAddr.toLowerCase()]: "token",
+    [routerAddr.toLowerCase()]: "router",
+  }
+  for (const txhash of block.transactions) {
+    const tx = await provider.getTransaction(txhash);
+    const fromName = names[tx.from.toLowerCase()] || tx.from;
+    const toName = names[tx.to.toLowerCase()] || tx.to;
+    if (fromName != tx.from || toName != tx.to) {
+      console.log(`- Tx ${tx.hash}: ${fromName} => ${toName}`);
+    }
+  }
+
+  console.log(`\nFinal balance of the sender ${senderAddr}`);
+  console.log(`- ${ethers.formatEther(await provider.getBalance(senderAddr))} KAIA`);
+  console.log(`- ${ethers.formatUnits(await token.balanceOf(senderAddr), tokenDecimals)} ${tokenSymbol}`);
 }
 
-async function main() {
-  try {
-    console.log("=== Starting Gasless Transaction Flow ===");
-
-    const appTxFee = ethers.parseUnits("0.01", "ether").toString();
-    const slippageBasisPoints = 500; // 5% = 500 basis points
-    console.log(`App transaction fee: ${ethers.formatUnits(appTxFee, 18)} KAIA`);
-    console.log(`Slippage tolerance: ${slippageBasisPoints}%`);
-
-    await sendGaslessTx(appTxFee, slippageBasisPoints);
-  } catch (error) {
-    console.error("Error in gasless transaction flow:", error);
-    console.error("Error details:", JSON.stringify(error, Object.getOwnPropertyNames(error)));
-  }
-}
-
-main();
+main().catch(console.error);

--- a/ethers-ext/example/v6/gasless/gasless.js
+++ b/ethers-ext/example/v6/gasless/gasless.js
@@ -3,14 +3,14 @@ const ethers = require("ethers6");
 const { Wallet, gasless } = require("@kaiachain/ethers-ext/v6");
 
 // Replace with ERC20 token address to be spent
-//const tokenAddr = "0xcB00BA2cAb67A3771f9ca1Fa48FDa8881B457750"; // Kairos:TEST token
-const tokenAddr = "0x8ebc32c078f5ecc8406ddDC785c8F0e2490C1081";
+const tokenAddr = "0xcB00BA2cAb67A3771f9ca1Fa48FDa8881B457750"; // Kairos:TEST token
+//const tokenAddr = "0x8ebc32c078f5ecc8406ddDC785c8F0e2490C1081";
 // Replace with your wallet address and private key
 const senderAddr = "0xa0Ee7A142d267C1f36714E4a8F75612F20a79720";
 const senderPriv = "0x2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6";
 
-//const provider = new ethers.JsonRpcProvider("https://public-en-kairos.node.kaia.io");
-const provider = new ethers.JsonRpcProvider("http://localhost:8559");
+const provider = new ethers.JsonRpcProvider("https://public-en-kairos.node.kaia.io");
+//const provider = new ethers.JsonRpcProvider("http://localhost:8559");
 const wallet = new Wallet(senderPriv, provider);
 
 const ERC20_ABI = [
@@ -36,7 +36,7 @@ async function main() {
 
   const network = await provider.getNetwork();
   const chainId = Number(network.chainId);
-  const router = await gasless.getGaslessSwapRouter(provider, chainId, "0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9");
+  const router = await gasless.getGaslessSwapRouter(provider, chainId);
   const routerAddr = await router.getAddress();
   const commissionRate = Number(await router.commissionRate());
   console.log(`\nGaslessSwapRouter address: ${routerAddr}`);
@@ -49,7 +49,7 @@ async function main() {
   const txs = [];
   if (approveRequired) {
     console.log("\nAdding ApproveTx because allowance is 0");
-    approveTx = await gasless.getApproveTx(
+    const approveTx = await gasless.getApproveTx(
       provider,
       senderAddr,
       tokenAddr,

--- a/ethers-ext/src/v6/gasless.ts
+++ b/ethers-ext/src/v6/gasless.ts
@@ -290,40 +290,28 @@ export async function getSwapTx(
 export async function sendGaslessTx(
   approveTxOrNull: string | null,
   swapTx: string,
-  provider?: ethers.Provider
+  provider: ethers.Provider
 ): Promise<string[]> {
   try {
-    if (provider) {
-      const network = await provider.getNetwork();
-      const chainId = Number(network.chainId);  
-      validateChainId(chainId);
+    const network = await provider.getNetwork();
+    const chainId = Number(network.chainId);  
+    validateChainId(chainId);
 
-      // Assert that provider is JsonRpcApiProvider
-      assert(
-        provider instanceof JsonRpcApiProvider,
-        "Provider is not JsonRpcApiProvider: cannot send kaia_sendRawTransactions",
-        "UNSUPPORTED_OPERATION",
-        {
-          operation: "sendGaslessTx",
-        }
-      );
-
-      if (approveTxOrNull) {
-        console.log("Sending both approve and swap transactions via RPC...");
-        return await provider.send("kaia_sendRawTransactions", [[approveTxOrNull, swapTx]]);
-      } else {
-        return await provider.send("kaia_sendRawTransactions", [[swapTx]]);
+    // Assert that provider is JsonRpcApiProvider
+    assert(
+      provider instanceof JsonRpcApiProvider,
+      "Provider is not JsonRpcApiProvider: cannot send kaia_sendRawTransactions",
+      "UNSUPPORTED_OPERATION",
+      {
+        operation: "sendGaslessTx",
       }
+    );
+
+    if (approveTxOrNull) {
+      console.log("Sending both approve and swap transactions via RPC...");
+      return await provider.send("kaia_sendRawTransactions", [[approveTxOrNull, swapTx]]);
     } else {
-      console.log("No provider available, simulating transaction sending...");
-      if (approveTxOrNull) {
-        return [
-          `0x${approveTxOrNull.slice(2, 10).padEnd(64, '0')}`,
-          `0x${swapTx.slice(2, 10).padEnd(64, '0')}`
-        ];
-      } else {
-        return [`0x${swapTx.slice(2, 10).padEnd(64, '0')}`];
-      }
+      return await provider.send("kaia_sendRawTransactions", [[swapTx]]);
     }
   } catch (error) {
     console.error("Error in sendGaslessTx:", error);

--- a/ethers-ext/test/v6/gasless.spec.ts
+++ b/ethers-ext/test/v6/gasless.spec.ts
@@ -238,17 +238,6 @@ describe("Gasless v6", () => {
       expect(result).to.be.an("array");
       expect(result.length).to.equal(2);
     });
-
-    it("should simulate transaction sending when no provider is given", async () => {
-      const approveTx = "0x5678";
-      const swapTx = "0x1234";
-      
-      const result = await sendGaslessTx(approveTx, swapTx);
-      expect(result).to.be.an("array");
-      expect(result.length).to.equal(2);
-      expect(result[0]).to.equal("0x5678000000000000000000000000000000000000000000000000000000000000");
-      expect(result[1]).to.equal("0x1234000000000000000000000000000000000000000000000000000000000000");
-    });
   });
 
   describe("isGaslessSupportedToken", () => {


### PR DESCRIPTION
- Update gasless example to use the gasless SDK functions.
- Relocate the example to `example/v6/gasless` to find it more easily.
- Remove test-purpose-only code in sendGaslessTx.

example/v6/gasless/gasless.js sample output:
```
Using token at address: 0x8ebc32c078f5ecc8406ddDC785c8F0e2490C1081

Initial balance of the sender 0xa0Ee7A142d267C1f36714E4a8F75612F20a79720
- 15.210230999999975724 KAIA
- 84.421645688482873818 TT

GaslessSwapRouter address: 0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9
- The token is supported: true
- Commission rate: 0 bps

Adding ApproveTx because allowance is 0

Calculating the amount of the token to be swapped...
- gasPrice: 27.5 gkei
- amountRepay: 0.0170775 KAIA
- minAmountOut: 1.0170775 KAIA
- amountIn: 1.05848020520746004 TT

Sending transactions...
- Tx sent: 0x953cd43f82e0609d751bc877dfd34572a002f50b6ae6cb9211027bcf6b619c4d
- Tx sent: 0x046ed2aeb7cd49c50be27ed23e5fe194d7cfc0966f7d590a0475be04f1c303ee

Waiting for transactions to be mined...
- Tx mined at block 5153
- Tx mined at block 5153

Listing the block's transactions related to the sender...
- Tx 0x7652596482ba32827326dbf0e7b0df40df6cada84361c5b0b526daead389281f: 0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC => sender
- Tx 0x953cd43f82e0609d751bc877dfd34572a002f50b6ae6cb9211027bcf6b619c4d: sender => token
- Tx 0x046ed2aeb7cd49c50be27ed23e5fe194d7cfc0966f7d590a0475be04f1c303ee: sender => router

Final balance of the sender 0xa0Ee7A142d267C1f36714E4a8F75612F20a79720
- 16.225721479999975724 KAIA
- 83.363165483275413778 TT
``` 