### PR TITLE
Bumped js-ext-core to 2.0.5

### DIFF
--- a/js-ext-core/package.json
+++ b/js-ext-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kaiachain/js-ext-core",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "license": "MIT",
   "main": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",


### PR DESCRIPTION
Bumped js-ext-core to 2.0.5 for inappbrowser issue handled in ethers v5