### PR TITLE
fix: correct net RPC return types to match Go implementation

### DIFF
--- a/web3rpc/rpc-specs/paths/net/networkID.yaml
+++ b/web3rpc/rpc-specs/paths/net/networkID.yaml
@@ -44,10 +44,10 @@ paths:
                   - type: object
                     properties:
                       result:
-                        type: string
-                        format: hex
+                        type: integer
+                        format: uint64
                         description: The integer of the network identifier. "1001" Kaia Kairos testnet."8217" Kaia Cypress mainnet.
-                        example: "1001"
+                        example: 1001
 
       x-codeSamples:
         - lang: "Shell"

--- a/web3rpc/rpc-specs/paths/net/version.yaml
+++ b/web3rpc/rpc-specs/paths/net/version.yaml
@@ -44,8 +44,7 @@ paths:
                     properties:
                       result:
                         type: string
-                        format: hex
-                        description: The integer of the kaia protocol version. "1001" Kaia Kairos testnet."8217" Kaia Cypress mainnet.
+                        description: The string representation of the kaia protocol version. "1001" Kaia Kairos testnet."8217" Kaia Cypress mainnet.
                         example: "1001"
 
       x-codeSamples:


### PR DESCRIPTION
## Description

Align RPC specification with actual Go implementation:
- net_version: remove hex format (Go returns decimal string)
- net_networkID: string -> integer (Go returns uint64)


```Go
// Version returns the current Kaia protocol version.
func (s *PublicNetAPI) Version() string {
	return fmt.Sprintf("%d", s.networkVersion)
}

// NetworkID returns the network identifier set by the command-line option --networkid.
func (s *PublicNetAPI) NetworkID() uint64 {
	return s.networkVersion
}
```

Ref: https://github.com/kaiachain/kaia/blob/e95a8dc23a14fc7f54ca8c291bea4b47eccf7d97/api/api_public_net.go#L58-L66