### PR TITLE
Fix: kaia-docs prod workflow not picking updated docs (PR#202 follow-up)

### DIFF
--- a/documentation/namespaces/eth.yaml
+++ b/documentation/namespaces/eth.yaml
@@ -100,6 +100,8 @@ paths:
     $ref: ../../web3rpc/rpc-specs/paths/eth/config/coinbase.yaml#/paths/~1eth~1config~1coinbase
   /eth/config/etherbase:
     $ref: ../../web3rpc/rpc-specs/paths/eth/config/etherbase.yaml#/paths/~1eth~1config~1etherbase
+  /eth/config/config:
+    $ref: ../../web3rpc/rpc-specs/paths/eth/config/config.yaml#/paths/~1eth~1config~1config
   /eth/config/protocolVersion:
     $ref: ../../web3rpc/rpc-specs/paths/eth/config/protocolVersion.yaml#/paths/~1eth~1config~1protocolVersion
 
@@ -112,6 +114,8 @@ paths:
     $ref: ../../web3rpc/rpc-specs/paths/eth/gas/maxPriorityFeePerGas.yaml#/paths/~1eth~1gas~1maxPriorityFeePerGas
   /eth/gas/gasPrice:
     $ref: ../../web3rpc/rpc-specs/paths/eth/gas/gasPrice.yaml#/paths/~1eth~1gas~1gasPrice
+  /eth/gas/blobBaseFee:
+    $ref: ../../web3rpc/rpc-specs/paths/eth/gas/blobBaseFee.yaml#/paths/~1eth~1gas~1blobBaseFee
   # eth/filter
   /eth/filter/getFilterLogs:
     $ref: ../../web3rpc/rpc-specs/paths/eth/filter/getFilterLogs.yaml#/paths/~1eth~1filter~1getFilterLogs
@@ -145,4 +149,8 @@ paths:
     $ref: ../../web3rpc/rpc-specs/paths/eth/miscellaneous/submitHashrate.yaml#/paths/~1eth~1miscellaneous~1submitHashrate
   /eth/miscellaneous/getProof:
     $ref: ../../web3rpc/rpc-specs/paths/eth/miscellaneous/getProof.yaml#/paths/~1eth~1miscellaneous~1getProof
+  /eth/miscellaneous/getBlobSidecars:
+    $ref: ../../web3rpc/rpc-specs/paths/eth/miscellaneous/getBlobSidecars.yaml#/paths/~1eth~1miscellaneous~1getBlobSidecars
+  /eth/miscellaneous/getBlobSidecarByTxHash:
+    $ref: ../../web3rpc/rpc-specs/paths/eth/miscellaneous/getBlobSidecarByTxHash.yaml#/paths/~1eth~1miscellaneous~1getBlobSidecarByTxHash
  

--- a/documentation/namespaces/eth.yaml
+++ b/documentation/namespaces/eth.yaml
@@ -25,10 +25,10 @@ paths:
     $ref: ../../web3rpc/rpc-specs/paths/eth/account/getBalance.yaml#/paths/~1eth~1account~1getBalance
   /eth/account/getCode:
     $ref: ../../web3rpc/rpc-specs/paths/eth/account/getCode.yaml#/paths/~1eth~1account~1getCode
-  /eth/account/getTransactionCount:
-    $ref: ../../web3rpc/rpc-specs/paths/eth/account/getTransactionCount.yaml#/paths/~1eth~1account~1getTransactionCount
   /eth/account/sign:
     $ref: ../../web3rpc/rpc-specs/paths/eth/account/sign.yaml#/paths/~1eth~1account~1sign
+  /eth/account/getTransactionCount:
+    $ref: ../../web3rpc/rpc-specs/paths/eth/account/getTransactionCount.yaml#/paths/~1eth~1account~1getTransactionCount
   /eth/account/getStorageAt:
     $ref: ../../web3rpc/rpc-specs/paths/eth/account/getStorageAt.yaml#/paths/~1eth~1account~1getStorageAt
 

--- a/web3rpc/rpc-specs/paths/eth/index.yaml
+++ b/web3rpc/rpc-specs/paths/eth/index.yaml
@@ -99,6 +99,8 @@ paths:
     $ref: ./config/coinbase.yaml#/paths/~1eth~1config~1coinbase
   /eth/config/etherbase:
     $ref: ./config/etherbase.yaml#/paths/~1eth~1config~1etherbase
+  /eth/config/config:
+    $ref: ./config/config.yaml#/paths/~1eth~1config~1config
   /eth/config/protocolVersion:
     $ref: ./config/protocolVersion.yaml#/paths/~1eth~1config~1protocolVersion
 
@@ -111,6 +113,8 @@ paths:
     $ref: ./gas/maxPriorityFeePerGas.yaml#/paths/~1eth~1gas~1maxPriorityFeePerGas
   /eth/gas/gasPrice:
     $ref: ./gas/gasPrice.yaml#/paths/~1eth~1gas~1gasPrice
+  /eth/gas/blobBaseFee:
+    $ref: ./gas/blobBaseFee.yaml#/paths/~1eth~1gas~1blobBaseFee
 
   # eth/filter
   /eth/filter/getFilterLogs:
@@ -145,4 +149,8 @@ paths:
     $ref: ./miscellaneous/submitHashrate.yaml#/paths/~1eth~1miscellaneous~1submitHashrate
   /eth/miscellaneous/getProof:
     $ref: ./miscellaneous/getProof.yaml#/paths/~1eth~1miscellaneous~1getProof
- 
+  /eth/miscellaneous/getBlobSidecars:
+    $ref: ./miscellaneous/getBlobSidecars.yaml#/paths/~1eth~1miscellaneous~1getBlobSidecars
+  /eth/miscellaneous/getBlobSidecarByTxHash:
+    $ref: ./miscellaneous/getBlobSidecarByTxHash.yaml#/paths/~1eth~1miscellaneous~1getBlobSidecarByTxHash
+


### PR DESCRIPTION
## Summary

Fixes the issue where the **kaia-docs prod workflow** was unable to pick up and generate updated documentation for kaia-docs as intended by the changes in **PR#202**.

## Root cause

The `documentation/namespaces/` manifests were out of sync with `web3rpc/rpc-specs/paths/`. The prod doc-generation workflow relies on these namespace files to discover and build docs; missing or mismatched refs prevented the new eth APIs from being included in the generated docs.

## Changes

- **`documentation/namespaces/eth.yaml`**
  - Align path refs with `web3rpc/rpc-specs/paths/eth/` (reorder `getTransactionCount` for consistency).
  - Add refs for: `eth/config/config`, `eth/gas/blobBaseFee`, `eth/miscellaneous/getBlobSidecars`, `eth/miscellaneous/getBlobSidecarByTxHash`.

- **`web3rpc/rpc-specs/paths/eth/index.yaml`**
  - Add entries for: `eth/config/config`, `eth/gas/blobBaseFee`, `eth/miscellaneous/getBlobSidecars`, `eth/miscellaneous/getBlobSidecarByTxHash`.

With namespace and rpc-specs in sync, the kaia-docs prod workflow can correctly pick up and generate docs for these APIs.

## Testing

- After merge, verify kaia-docs prod workflow runs and publishes the updated docs.
