### PR TITLE
Note archive-node requirement for getCouncil/getCouncilSize on permissionless

### DIFF
--- a/web3rpc/rpc-specs/paths/kaia/block/getCouncil.yaml
+++ b/web3rpc/rpc-specs/paths/kaia/block/getCouncil.yaml
@@ -23,6 +23,8 @@ paths:
         
         *In versions earlier than Kaia v1.7.0, only integer block number, the string "earliest" and "latest" are available.*
 
+        *On permissionless networks, this method reads the council from the state at the queried block. Non-archive (pruned) nodes only retain recent state, so querying historical blocks requires an archive node; otherwise it fails with a "missing trie node" error.*
+
         **JSONRPC:** `kaia_getCouncil`
       tags:
         - kaia

--- a/web3rpc/rpc-specs/paths/kaia/block/getCouncilSize.yaml
+++ b/web3rpc/rpc-specs/paths/kaia/block/getCouncilSize.yaml
@@ -19,6 +19,8 @@ paths:
 
         **NOTE:** *In versions earlier than Kaia v1.7.0, only integer block number, the string "earliest" and "latest" are available.*
 
+        *On permissionless networks, this method reads the council from the state at the queried block. Non-archive (pruned) nodes only retain recent state, so querying historical blocks requires an archive node; otherwise it fails with a "missing trie node" error.*
+
         **JSONRPC:** `kaia_getCouncilSize`
       tags:
         - kaia

--- a/web3rpc/rpc-specs/paths/klay/block/getCouncil.yaml
+++ b/web3rpc/rpc-specs/paths/klay/block/getCouncil.yaml
@@ -23,6 +23,8 @@ paths:
         
         *In versions earlier than Kaia v1.7.0, only integer block number, the string "earliest" and "latest" are available.*
 
+        *On permissionless networks, this method reads the council from the state at the queried block. Non-archive (pruned) nodes only retain recent state, so querying historical blocks requires an archive node; otherwise it fails with a "missing trie node" error.*
+
         **JSONRPC:** `klay_getCouncil`
       tags:
         - klay

--- a/web3rpc/rpc-specs/paths/klay/block/getCouncilSize.yaml
+++ b/web3rpc/rpc-specs/paths/klay/block/getCouncilSize.yaml
@@ -19,6 +19,8 @@ paths:
 
         **NOTE:** *In versions earlier than Kaia v1.7.0, only integer block number, the string "earliest" and "latest" are available.*
 
+        *On permissionless networks, this method reads the council from the state at the queried block. Non-archive (pruned) nodes only retain recent state, so querying historical blocks requires an archive node; otherwise it fails with a "missing trie node" error.*
+
         **JSONRPC:** `klay_getCouncilSize`
       tags:
         - klay


### PR DESCRIPTION
## What

Add a note to the `getCouncil` / `getCouncilSize` RPC docs (both `kaia` and `klay` namespaces) that, on permissionless networks, historical queries require an archive node.

## Why

These methods read the council from the state at the queried block. On non-archive (pruned) nodes only recent state is retained, so querying historical blocks fails with a `missing trie node` error. This wasn't documented, so the spec implied any block is queryable.

> *On permissionless networks, this method reads the council from the state at the queried block. Non-archive (pruned) nodes only retain recent state, so querying historical blocks requires an archive node; otherwise it fails with a "missing trie node" error.*


